### PR TITLE
Change the scope field from GLOBAL to DOMAIN in escalation_policy of monitoring service

### DIFF
--- a/proto/spaceone/api/monitoring/v1/escalation_policy.proto
+++ b/proto/spaceone/api/monitoring/v1/escalation_policy.proto
@@ -39,7 +39,7 @@ service EscalationPolicy {
             ],
             "repeat_count": 2,
             "finish_condition": "ACKNOWLEDGED",
-            "scope": "GLOBAL",
+            "scope": "DOMAIN",
             "tags": {},
             "domain_id": "domain-58010aa2e451",
             "created_at": "2022-06-21T09:22:45.340Z"
@@ -81,7 +81,7 @@ service EscalationPolicy {
             ],
             "repeat_count": 1,
             "finish_condition": "RESOLVED",
-            "scope": "GLOBAL",
+            "scope": "DOMAIN",
             "tags": {},
             "domain_id": "domain-58010aa2e451",
             "created_at": "2022-06-21T09:22:45.340Z"
@@ -118,7 +118,7 @@ service EscalationPolicy {
             ],
             "repeat_count": 1,
             "finish_condition": "RESOLVED",
-            "scope": "GLOBAL",
+            "scope": "DOMAIN",
             "tags": {},
             "domain_id": "domain-58010aa2e451",
             "created_at": "2022-06-21T09:22:45.340Z"
@@ -159,7 +159,7 @@ service EscalationPolicy {
                 }
             ],
             "finish_condition": "ACKNOWLEDGED",
-            "scope": "GLOBAL",
+            "scope": "DOMAIN",
             "tags": {},
             "domain_id": "domain-58010aa2e451",
             "created_at": "2022-05-25T09:31:38.573Z"
@@ -187,7 +187,7 @@ service EscalationPolicy {
                         }
                     ],
                     "finish_condition": "ACKNOWLEDGED",
-                    "scope": "GLOBAL",
+                    "scope": "DOMAIN",
                     "tags": {},
                     "domain_id": "domain-58010aa2e451",
                     "created_at": "2022-05-25T09:31:15.150Z"
@@ -205,7 +205,7 @@ service EscalationPolicy {
                         }
                     ],
                     "finish_condition": "ACKNOWLEDGED",
-                    "scope": "GLOBAL",
+                    "scope": "DOMAIN",
                     "tags": {},
                     "domain_id": "domain-58010aa2e451",
                     "created_at": "2022-05-25T09:31:38.573Z"
@@ -307,7 +307,7 @@ message GetEscalationPolicyRequest {
 message EscalationPolicyQuery {
     enum EscalationPolicyScope {
         SCOPE_NONE = 0;
-        GLOBAL = 1;
+        DOMAIN = 1;
         PROJECT = 2;
     }
 
@@ -338,7 +338,7 @@ message EscalationPolicyQuery {
 message EscalationPolicyInfo {
     enum EscalationPolicyScope {
         SCOPE_NONE = 0;
-        GLOBAL = 1;
+        DOMAIN = 1;
         PROJECT = 2;
     }
 


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
* Change the scope field from GLOBAL to DOMAIN in escalation_policy of monitoring service