### PR TITLE
feat: add query field to RemoteRepositoryQuery

### DIFF
--- a/proto/spaceone/api/repository/v2/remote_repository.proto
+++ b/proto/spaceone/api/repository/v2/remote_repository.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package spaceone.api.repository.v2;
 
 import "google/api/annotations.proto";
+import "spaceone/api/core/v1/query.proto";
 
 
 service RemoteRepository {
@@ -22,9 +23,11 @@ message GetRemoteRepository {
 
 message RemoteRepositoryQuery {
     // is_required: false
-    string name = 1;
+    spaceone.api.core.v1.Query query = 1;
     // is_required: false
-    string version = 2;
+    string name = 2;
+    // is_required: false
+    string version = 3;
 }
 
 message RemoteRepositoryInfo {


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
RemoteRepositoryQuery of repository v2 was missing query field. 
It can be problem when user execute `spacectl list repository_v2.RemoteRepository`
To fix this issue, i've added qeury field to RemoteRepositoryQuery of repository v2

### Known issue