### PR TITLE
feat: Update protobuf  messages for repo_v2

### DIFF
--- a/proto/spaceone/api/repository/v2/provider.proto
+++ b/proto/spaceone/api/repository/v2/provider.proto
@@ -32,10 +32,6 @@ service Provider {
     rpc list (ProviderQuery) returns (ProvidersInfo) {
         option (google.api.http) = { post: "/repository/v2/providers/list" };
     }
-
-    rpc stat (ProviderStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/repository/v2/provider/stat" };
-    }
 }
 
 enum SyncMode {
@@ -65,7 +61,7 @@ message CreateProviderRequest {
     // is_required: false
     string icon = 9;
     // is_required: false
-    string reference_url = 10;
+    google.protobuf.Struct reference = 10;
     // is_required: false
     google.protobuf.ListValue labels = 11;
     // is_required: false
@@ -94,7 +90,7 @@ message UpdateProviderRequest {
     // is_required: false
     string icon = 9;
     // is_required: false
-    string reference_url = 10;
+    google.protobuf.Struct reference = 10;
     // is_required: false
     google.protobuf.ListValue labels = 11;
     // is_required: false
@@ -127,15 +123,8 @@ message ProviderQuery {
     // is_required: false
     string name = 3;
     // is_required: false
-    google.protobuf.Struct sync_options = 4;
+    SyncMode sync_mode = 4;
     // is_required: false
-    string domain_id = 21;
-}
-
-message ProviderStatQuery {
-    // is_required: true
-    spaceone.api.core.v1.StatisticsQuery query = 1;
-    // is_required: true
     string domain_id = 21;
 }
 
@@ -149,7 +138,7 @@ message ProviderInfo {
     google.protobuf.Struct schema_options = 7;
     string color = 8;
     string icon = 9;
-    string reference_url = 10;
+    google.protobuf.Struct reference = 10;
     google.protobuf.ListValue labels = 11;
     google.protobuf.Struct tags = 12;
     string domain_id = 21;

--- a/proto/spaceone/api/repository/v2/remote_repository.proto
+++ b/proto/spaceone/api/repository/v2/remote_repository.proto
@@ -23,11 +23,9 @@ message GetRemoteRepository {
 
 message RemoteRepositoryQuery {
     // is_required: false
-    spaceone.api.core.v1.Query query = 1;
+    string name = 1;
     // is_required: false
-    string name = 2;
-    // is_required: false
-    string version = 3;
+    string version = 2;
 }
 
 message RemoteRepositoryInfo {


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Some message fields has been updated
  - Reference_url has been renamed to reference(also, data type has been changed to struct)
  - ProviderQuery had wrong field(sync_option), it has been changed to sync_mode
- Unnecessary field  in RemoteRepositoryQuery has been deleted
- Repository resources do not have a stat verb.
  - And providerStatQuery message has been deleted

*) Refer to our api docs.

### Known issue