### PR TITLE
Modify repository service http request url at proto file

### DIFF
--- a/proto/spaceone/api/repository/v1/plugin.proto
+++ b/proto/spaceone/api/repository/v1/plugin.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.repository.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/repository/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -114,7 +116,10 @@ service Plugin {
         }
      */
     rpc register (CreatePluginRequest) returns (PluginInfo) {
-        option (google.api.http) = { post: "/repository/v1/plugins" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/register"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Plugin registered. A Plugin can be updated only if its Repository's `repository_type` is `local`. You can make changes in Plugin settings, including `template` and its options, `schema`.
@@ -213,7 +218,10 @@ service Plugin {
         }
      */
     rpc update (UpdatePluginRequest) returns (PluginInfo) {
-        option (google.api.http) = { put: "/repository/v1/plugin/{plugin_id}" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/update"
+            body: "*"
+        };
     }
     /*
     desc: Deregisters and deletes a specific Plugin. You must specify the `plugin_id` of the Plugin to deregister.
@@ -249,7 +257,10 @@ service Plugin {
         }
      */
     rpc deregister (PluginRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/repository/v1/plugin/{plugin_id}" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/deregister"
+            body: "*"
+        };
     }
     /*
     desc: Enables a specific Plugin. If the Plugin is enabled, the Plugin can be used as its parameter `state` becomes `ENABLED`.
@@ -285,7 +296,10 @@ service Plugin {
         }
      */
     rpc enable (PluginRequest) returns (PluginInfo) {
-        option (google.api.http) = { put: "/repository/v1/plugin/{plugin_id}/enable" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/enable"
+            body: "*"
+        };
     }
     /*
     desc: Disables a specific Plugin. If the Plugin is disabled, the Plugin cannot be used as its parameter `state` becomes `DISABLED`.
@@ -321,7 +335,10 @@ service Plugin {
         }
      */
     rpc disable (PluginRequest) returns (PluginInfo) {
-        option (google.api.http) = { put: "/repository/v1/plugin/{plugin_id}/disable" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/disable"
+            body: "*"
+        };
     }
     /*
     desc: Gets all version data of a specific Plugin from its Repository. The parameter `plugin_id` is used as an identifier of a Plugin to get version data.
@@ -343,7 +360,10 @@ service Plugin {
         }
      */
     rpc get_versions (RepositoryPluginRequest) returns (VersionsInfo) {
-        option (google.api.http) = { get: "/repository/v1/plugins/{plugin_id}/versions" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/get-versions"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Plugin. Prints detailed information about the Plugin, including  `image`, `registry_url`, and `state`.
@@ -379,7 +399,10 @@ service Plugin {
         }
      */
     rpc get (GetRepositoryPluginRequest) returns (PluginInfo) {
-        option (google.api.http) = { get: "/repository/v1/plugins/{plugin_id}" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Plugins registered in a specific Repository. The parameter `repository_id` is used as an identifier of a Repository to get its list of Plugins. You can use a query to get a filtered list of Plugins.
@@ -443,14 +466,15 @@ service Plugin {
      */
     rpc list (PluginQuery) returns (PluginsInfo) {
         option (google.api.http) = {
-            get: "/repository/v1/plugins"
-            additional_bindings {
-                post: "/repository/v1/plugins/search"
-            }
+            post: "repository/v1/plugin/list"
+            body: "*"
         };
     }
     rpc stat (PluginStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/repository/v1/plugins/stat" };
+        option (google.api.http) = {
+            post: "repository/v1/plugin/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/repository/v1/policy.proto
+++ b/proto/spaceone/api/repository/v1/policy.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.repository.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/repository/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -45,7 +47,10 @@ service Policy {
         }
      */
     rpc create (CreatePolicyRequest) returns (PolicyInfo) {
-        option (google.api.http) = { post: "/repository/v1/policies" };
+        option (google.api.http) = {
+            post: "/repository/v1/policy/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Policy. You can make changes in Policy settings, including `name`, `labels`, `tags`, and `permissions`. The parameter `policy_id` cannot be updated.
@@ -79,7 +84,10 @@ service Policy {
         }
      */
     rpc update (UpdatePolicyRequest) returns (PolicyInfo) {
-        option (google.api.http) = { put: "/repository/v1/policy/{policy}" };
+        option (google.api.http) = {
+            post: "/repository/v1/policy/update"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Policy. You must specify the `policy_id` of the Policy to delete, as the `policy_id` is an identifier of Policy resources.
@@ -89,7 +97,10 @@ service Policy {
         }
      */
     rpc delete (PolicyRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/repository/v1/policy/{policy}" };
+        option (google.api.http) = {
+            post: "/repository/v1/policy/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Policy. You must specify the `policy_id` of the Policy to get, as the `policy_id` is an identifier of Policy resources. You can use the parameter `repository_id` to limit the scope of the method to a specific Repository.
@@ -119,7 +130,10 @@ service Policy {
         }
      */
     rpc get (GetRepositoryPolicyRequest) returns (PolicyInfo) {
-        option (google.api.http) = { get: "/repository/v1/policies/{policy}" };
+        option (google.api.http) = {
+            post: "/repository/v1/policy/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Policies in a specific Repository. The parameter `repository_id` is used as an identifier of a Repository to get its list of Policies. You can use a query to get a filtered list of Policies.
@@ -173,14 +187,15 @@ service Policy {
      */
     rpc list (PolicyQuery) returns (PoliciesInfo) {
         option (google.api.http) = {
-            get: "/repository/v1/policies"
-            additional_bindings {
-                post: "/repository/v1/policies/search"
-            }
+            post: "/repository/v1/policy/list"
+            body: "*"
         };
     }
     rpc stat (PolicyStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/repository/v1/policies/stat" };
+        option (google.api.http) = {
+            post: "/repository/v1/policy/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/repository/v1/repository.proto
+++ b/proto/spaceone/api/repository/v1/repository.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.repository.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/repository/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -29,7 +31,10 @@ service Repository {
         }
      */
     rpc register (CreateRepositoryRequest) returns (RepositoryInfo) {
-        option (google.api.http) = { post: "/repository/v1/repositories" };
+        option (google.api.http) = {
+            post: "/repository/v1/repository/register"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Repository registered. You must specify the `repository_id` of the Repository to update. You can make changes in Repository settings, including `name`.
@@ -48,7 +53,10 @@ service Repository {
         }
      */
     rpc update (UpdateRepositoryRequest) returns (RepositoryInfo) {
-        option (google.api.http) = { put: "/repository/v1/repository/{repository_id}" };
+        option (google.api.http) = {
+            post: "/repository/v1/repository/update"
+            body: "*"
+        };
     }
     /*
     desc: Deregisters and deletes a specific Repository. You must specify the `repository_id` of the Repository to deregister.
@@ -58,7 +66,10 @@ service Repository {
         }
      */
     rpc deregister (RepositoryRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/repository/v1/repository/{repository_id}" };
+        option (google.api.http) = {
+            post: "/repository/v1/repository/deregister"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Repository. Prints detailed information about the Repository, including  `name`, `repository_type`, and `endpoint`.
@@ -76,7 +87,10 @@ service Repository {
         }
      */
     rpc get (GetRepositoryRequest) returns (RepositoryInfo) {
-        option (google.api.http) = { get: "/repository/v1/repositories/{repository_id}" };
+        option (google.api.http) = {
+            post: "/repository/v1/repository/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Repositories regardless of `domain`. You can use a query to get a filtered list of Repositories.
@@ -101,14 +115,15 @@ service Repository {
      */
     rpc list (RepositoryQuery) returns (RepositoriesInfo) {
         option (google.api.http) = {
-            get: "/repository/v1/repositories"
-            additional_bindings {
-                post: "/repository/v1/repositories/search"
-            }
+            post: "/repository/v1/repository/list"
+            body: "*"
         };
     }
     rpc stat (RepositoryStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/repository/v1/repositories/stat" };
+        option (google.api.http) = {
+            post: "/repository/v1/repository/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/repository/v1/schema.proto
+++ b/proto/spaceone/api/repository/v1/schema.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.repository.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/repository/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -46,7 +48,10 @@ service Schema {
         }
      */
     rpc create (CreateSchemaRequest) returns (SchemaInfo) {
-        option (google.api.http) = { post: "/repository/v1/schemas" };
+        option (google.api.http) = {
+            post: "/repository/v1/schema/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Schema. You can make changes in Schema settings, including `name`, `schema`, `labels`, and `tags`.
@@ -78,7 +83,10 @@ service Schema {
         }
      */
     rpc update (UpdateSchemaRequest) returns (SchemaInfo) {
-        option (google.api.http) = { put: "/repository/v1/schema/{schema}" };
+        option (google.api.http) = {
+            post: "/repository/v1/schema/update"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Schema. You must specify the `name` of the Schema to delete, as the `name` is an identifier of Schema resources.
@@ -88,7 +96,10 @@ service Schema {
         }
      */
     rpc delete (SchemaRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/repository/v1/schema/{schema}" };
+        option (google.api.http) = {
+            post: "/repository/v1/schema/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Schema. You must specify the `name` of the Schema to get, as the `name` is an identifier of Schema resources. You can use the parameter `repository_id` to limit the scope of the method to a specific Repository.
@@ -117,7 +128,10 @@ service Schema {
         }
      */
     rpc get (GetRepositorySchemaRequest) returns (SchemaInfo) {
-        option (google.api.http) = { get: "/repository/v1/schemas/{schema}" };
+        option (google.api.http) = {
+            post: "/repository/v1/schema/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Schemas in a specific Repository. The parameter `repository_id` is used as an identifier of a Repository to get its list of Schemas. You can use a query to get a filtered list of Schemas.
@@ -154,14 +168,15 @@ service Schema {
      */
     rpc list (SchemaQuery) returns (SchemasInfo) {
         option (google.api.http) = {
-            get: "/repository/v1/schemas"
-            additional_bindings {
-                post: "/repository/v1/schemas/search"
-            }
+            post: "/repository/v1/schema/list"
+            body: "*"
         };
     }
     rpc stat (SchemaStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/repository/v1/schemas/stat" };
+        option (google.api.http) = {
+            post: "/repository/v1/schema/stat"
+            body: "*"
+        };
     }
 }
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
### Description
- modify`repository` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate Go code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 


### Known issue