### PR TITLE
Modify monitoring service http request url at proto file

### DIFF
--- a/proto/spaceone/api/monitoring/plugin/data_source.proto
+++ b/proto/spaceone/api/monitoring/plugin/data_source.proto
@@ -3,6 +3,8 @@ desc: A DataSource is a plugin instance receiving Metric and Log data from cloud
  */
 syntax = "proto3";
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/plugin";
+
 package spaceone.api.monitoring.plugin;
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";

--- a/proto/spaceone/api/monitoring/plugin/event.proto
+++ b/proto/spaceone/api/monitoring/plugin/event.proto
@@ -3,6 +3,8 @@ desc: An Event is data created by an external monitoring system and collected by
  */
 syntax = "proto3";
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/plugin";
+
 package spaceone.api.monitoring.plugin;
 
 import "google/protobuf/struct.proto";

--- a/proto/spaceone/api/monitoring/plugin/log.proto
+++ b/proto/spaceone/api/monitoring/plugin/log.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.plugin;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/plugin";
+
 import "google/protobuf/struct.proto";
 
 service Log {

--- a/proto/spaceone/api/monitoring/plugin/metric.proto
+++ b/proto/spaceone/api/monitoring/plugin/metric.proto
@@ -3,6 +3,8 @@ desc: A Metric is a monitoring metric data delivered from an external cloud serv
  */
 syntax = "proto3";
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/plugin";
+
 package spaceone.api.monitoring.plugin;
 
 import "google/protobuf/struct.proto";

--- a/proto/spaceone/api/monitoring/plugin/webhook.proto
+++ b/proto/spaceone/api/monitoring/plugin/webhook.proto
@@ -3,6 +3,8 @@ desc: A Webhook is a plugin receiving data from external monitoring systems.
  */
 syntax = "proto3";
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/plugin";
+
 package spaceone.api.monitoring.plugin;
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";

--- a/proto/spaceone/api/monitoring/v1/alert.proto
+++ b/proto/spaceone/api/monitoring/v1/alert.proto
@@ -3,6 +3,8 @@ desc: An Alert, a set of Events, is the smallest unit to manage incidents.
  */
 syntax = "proto3";
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 package spaceone.api.monitoring.v1;
 
 import "google/protobuf/empty.proto";
@@ -43,7 +45,10 @@ service Alert {
         }
      */
     rpc create (CreateAlertRequest) returns (AlertInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/alerts" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/create",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Alert. You can make changes in Alert settings, including the `title`, `description`, `responder`, `state`, and `urgency`. The `responder` of the Alert is a User who is assigned to respond to the Alert.
@@ -77,7 +82,10 @@ service Alert {
         }
      */
     rpc update (UpdateAlertRequest) returns (AlertInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/alert/{alert_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/update",
+            body: "*"
+        };
     }
     /*
     desc: Updates the state of an Alert via callback URL by creating a temporary `access_key` while generating a Notification about the Alert.
@@ -89,13 +97,22 @@ service Alert {
         }
      */
     rpc update_state (UpdateAlertStateRequest) returns (AlertInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/alert/{alert_id}/{access_key}/{state}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/update-state",
+            body: "*"
+        };
     }
     rpc merge (MergeAlertRequest) returns (AlertInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/alerts/merge" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/merge",
+            body: "*"
+        };
     }
     rpc snooze (SnoozeAlertRequest) returns (AlertInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/alert/{alert_id}/snooze" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/snooze",
+            body: "*"
+        };
     }
     /*
     desc: Adds a responder who receives a Notification about an Alert.
@@ -134,7 +151,10 @@ service Alert {
          }
      */
     rpc add_responder (AlertResponderRequest) returns (AlertInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/alert/{alert_id}/responders" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/add-responder",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a responder who receives a Notification about an Alert.
@@ -167,13 +187,22 @@ service Alert {
         }
      */
     rpc remove_responder (AlertResponderRequest) returns (AlertInfo) {
-        option (google.api.http) = { delete: "/monitoring/v1/alert/{alert_id}/responders" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/remove-responder",
+            body: "*"
+        };
     }
     rpc add_project_dependency (AlertProjectDependencyRequest) returns (AlertInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/alert/{alert_id}/project-dependencies" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/add-project-dependency",
+            body: "*"
+        };
     }
     rpc remove_project_dependency (AlertProjectDependencyRequest) returns (AlertInfo) {
-        option (google.api.http) = { delete: "/monitoring/v1/alert/{alert_id}/project-dependency/{project_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/remove-project-dependency",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Alert and remove it from the list of Alerts. You must specify the `alert_id` of the Alert to delete.
@@ -184,7 +213,10 @@ service Alert {
          }
      */
     rpc delete (AlertRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/monitoring/v1/alert/{alert_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/delete",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Alert. Prints detailed information about the Alert.
@@ -215,7 +247,10 @@ service Alert {
         }
      */
     rpc get (GetAlertRequest) returns (AlertInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/alert/{alert_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Alerts. You can use a query to get a filtered list of Alerts.
@@ -289,14 +324,15 @@ service Alert {
      */
     rpc list (AlertQuery) returns (AlertsInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/alerts"
-            additional_bindings {
-                post: "/monitoring/v1/alerts/search"
-            }
+            post: "/monitoring/v1/alert/list",
+            body: "*"
         };
     }
     rpc stat (AlertStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/alerts/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/alert/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/data_source.proto
+++ b/proto/spaceone/api/monitoring/v1/data_source.proto
@@ -3,6 +3,8 @@ desc: A DataSource is a plugin instance collecting `metric` and `log` data from 
  */
 syntax = "proto3";
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 package spaceone.api.monitoring.v1;
 
 import "google/protobuf/empty.proto";
@@ -75,7 +77,10 @@ service DataSource {
         }
     */
     rpc register (RegisterDataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/data-sources" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/register",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific DataSource. You can make changes in DataSource settings, including `name` and `tags`.
@@ -131,7 +136,10 @@ service DataSource {
         }
     */
     rpc update (UpdateDataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/data-source/{data_source_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/update",
+            body: "*"
+        };
     }
     /*
     desc: Enables a specific DataSource. By enabling a DataSource, you can communicate with an external cloud service via the plugin.
@@ -185,7 +193,10 @@ service DataSource {
         }
     */
     rpc enable (DataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/data-source/{data_source_id}/enable" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/enable",
+            body: "*"
+        };
     }
     /*
     desc: Disables a specific DataSource. By disabling a DataSource, you can block communication with an external cloud service via the plugin.
@@ -239,7 +250,10 @@ service DataSource {
       }
     */
     rpc disable (DataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/data-source/{data_source_id}/disable" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/disable",
+            body: "*"
+        };
     }
     /*
     desc: Deregisters and deletes a specific DataSource. You must specify the `data_source_id` of the DataSource to deregister.
@@ -250,7 +264,10 @@ service DataSource {
       }
     */
     rpc deregister (DataSourceRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/monitoring/v1/data-source/{data_source_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/deregister",
+            body: "*"
+        };
     }
     /*
     desc: Updates the plugin of a specific DataSource. This method resets the plugin data in the DataSource to update the `metadata`.
@@ -307,7 +324,10 @@ service DataSource {
         }
     */
     rpc update_plugin (UpdateDataSourcePluginRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/data-source/{data_source_id}/plugin" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/update-plugin",
+            body: "*"
+        };
     }
     /*
     desc: Verifies the plugin of a specific DataSource. This method validates the plugin data, `version` and `endpoint`.
@@ -318,7 +338,10 @@ service DataSource {
         }
     */
     rpc verify_plugin (DataSourceRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { put: "/monitoring/v1/data-source/{data_source_id}/plugin/verify" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/verify-plugin",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific DataSource. Prints detailed information about the DataSource, including `name`, `state`, and `plugin_info`.
@@ -364,7 +387,10 @@ service DataSource {
         }
     */
     rpc get (GetDataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/data-source/{data_source_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all DataSources. You can use a query to get a filtered list of DataSources.
@@ -416,14 +442,15 @@ service DataSource {
     */
     rpc list (DataSourceQuery) returns (DataSourcesInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/data-sources"
-            additional_bindings {
-                post: "/monitoring/v1/data-sources/search"
-            }
+            post: "/monitoring/v1/data-source/list",
+            body: "*"
         };
     }
     rpc stat (DataSourceStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/data-sources/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/data-source/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/escalation_policy.proto
+++ b/proto/spaceone/api/monitoring/v1/escalation_policy.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -46,7 +48,10 @@ service EscalationPolicy {
         }
      */
     rpc create (CreateEscalationPolicyRequest) returns (EscalationPolicyInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/escalation-policies" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/escalation-policy/create",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific EscalationPolicy. You can make changes in EscalationPolicy settings, including the name, the escalation process, and the number of iterations.
@@ -88,7 +93,10 @@ service EscalationPolicy {
         }
      */
     rpc update (UpdateEscalationPolicyRequest) returns (EscalationPolicyInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/escalation-policy/{escalation_policy_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/escalation-policy/update",
+            body: "*"
+        };
     }
     /*
     desc: Sets a specific EscalationPolicy as default. Only policies configured as global can be set as default. When a Project is created, even if you did not configure any policy to the Project, the default policy set by this api method is applied.
@@ -125,7 +133,10 @@ service EscalationPolicy {
         }
      */
     rpc set_default (EscalationPolicyRequest) returns (EscalationPolicyInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/escalation-policy/{escalation_policy_id}/set-default" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/escalation-policy/set-default",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific EscalationPolicy. Deletes the EscalationPolicy with the escalation_policy_id from the deletion request.
@@ -136,7 +147,10 @@ service EscalationPolicy {
         }
      */
     rpc delete (EscalationPolicyRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/monitoring/v1/escalation-policy/{escalation_policy_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/escalation-policy/delete",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific EscalationPolicy. Prints detailed information about the EscalationPolicy, including the name, rules, and termination conditions.
@@ -166,7 +180,10 @@ service EscalationPolicy {
         }
      */
     rpc get (GetEscalationPolicyRequest) returns (EscalationPolicyInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/escalation-policy/{escalation_policy_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/escalation-policy/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all EscalationPolicies. You can use a query to get a filtered list of EscalationPolicies.
@@ -216,14 +233,15 @@ service EscalationPolicy {
      */
     rpc list (EscalationPolicyQuery) returns (EscalationPoliciesInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/escalation-policies"
-            additional_bindings {
-                post: "/monitoring/v1/escalation-policies/search"
-            }
+            post: "/monitoring/v1/escalation-policy/list",
+            body: "*"
         };
     }
     rpc stat (EscalationPolicyStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/escalation-policies/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/escalation-policy/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/event.proto
+++ b/proto/spaceone/api/monitoring/v1/event.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -16,7 +18,10 @@ service Event {
     desc: Creates a new Event. The Event creation process starts with validation checking whether the input data is from a webhook or not. After the input data is validated, the data is processed and used to create the Event.
      */
     rpc create (CreateEventRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { post: "/monitoring/v1/webhook/{webhook_id}/{access_key}/events" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event/create",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Event matching the input parameters, `event_id` and `domain_id`. Prints detailed information about the Event.
@@ -66,7 +71,10 @@ service Event {
         }
      */
     rpc get (GetEventRequest) returns (EventInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/event/{event_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Events. You must specify the `domain_id`. You can use a query to get a filtered list of Events.
@@ -162,14 +170,15 @@ service Event {
      */
     rpc list (EventQuery) returns (EventsInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/events"
-            additional_bindings {
-                post: "/monitoring/v1/events/search"
-            }
+            post: "/monitoring/v1/event/list",
+            body: "*"
         };
     }
     rpc stat (EventStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/events/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/event_rule.proto
+++ b/proto/spaceone/api/monitoring/v1/event_rule.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -57,7 +59,10 @@ service EventRule {
          }
      */
     rpc create (CreateEventRuleRequest) returns (EventRuleInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/event-rules" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event-rule/create",
+            body: "*"
+        };
     }
     /*
     desc: Changes a priority order between EventRules to apply. EventRules are filtered by the order configured.
@@ -104,7 +109,10 @@ service EventRule {
          }
      */
     rpc update (UpdateEventRuleRequest) returns (EventRuleInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/event-rule/{event_rule_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event-rule/update",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific EventRule. You can make changes in EventRule settings.
@@ -144,7 +152,10 @@ service EventRule {
          }
      */
     rpc change_order (ChangeEventRuleOrderRequest) returns (EventRuleInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/event-rule/{event_rule_id}/order" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event-rule/change-order",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific EventRule. You must assign an EventRule resource to delete by specifying `event_rule_id`.
@@ -155,7 +166,10 @@ service EventRule {
          }
      */
     rpc delete (EventRuleRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/monitoring/v1/event-rule/{event_rule_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event-rule/delete",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific EventRule. Prints detailed information about the EventRule.
@@ -192,7 +206,10 @@ service EventRule {
          }
      */
     rpc get (GetEventRuleRequest) returns (EventRuleInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/event-rule/{event_rule_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event-rule/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all EventRules. You can use a query to get a filtered list of EventRules. For example, you can adjust the scope of the list to a certain Project or Domain.
@@ -259,14 +276,15 @@ service EventRule {
      */
     rpc list (EventRuleQuery) returns (EventRulesInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/event-rules"
-            additional_bindings {
-                post: "/monitoring/v1/event-rules/search"
-            }
+            post: "/monitoring/v1/event-rule/list",
+            body: "*"
         };
     }
     rpc stat (EventRuleStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/event-rules/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/event-rule/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/log.proto
+++ b/proto/spaceone/api/monitoring/v1/log.proto
@@ -2,13 +2,18 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 
 
 service Log {
     rpc list (LogRequest) returns (LogDataInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/data-source/{data_source_id}/logs" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/log/list",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/maintenance_window.proto
+++ b/proto/spaceone/api/monitoring/v1/maintenance_window.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "spaceone/api/core/v1/query.proto";
@@ -39,7 +41,10 @@ service MaintenanceWindow {
          }
      */
     rpc create (CreateMaintenanceWindowRequest) returns (MaintenanceWindowInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/maintenance-windows" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/maintenance-window/create",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific MaintenanceWindow. You can make changes in MaintenanceWindow settings including, the `title` and the schedule.
@@ -70,7 +75,10 @@ service MaintenanceWindow {
          }
      */
     rpc update (UpdateMaintenanceWindowRequest) returns (MaintenanceWindowInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/maintenance-window/{maintenance_window_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/maintenance-window/update",
+            body: "*"
+        };
     }
     /*
     desc: Closes a MaintenanceWindow by changing the state of the MaintenanceWindow to `CLOSED` when the maintenance is completed. As the MaintenanceWindow is not deleted but closed, the maintenance history remains undeleted.
@@ -97,7 +105,10 @@ service MaintenanceWindow {
          }
      */
     rpc close (MaintenanceWindowRequest) returns (MaintenanceWindowInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/maintenance-window/{maintenance_window_id}/close" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/maintenance-window/close",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific MaintenanceWindow. Prints detailed information about the MaintenanceWindow, including the title and the schedule.
@@ -124,7 +135,10 @@ service MaintenanceWindow {
          }
      */
     rpc get (GetMaintenanceWindowRequest) returns (MaintenanceWindowInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/maintenance-window/{maintenance_window_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/maintenance-window/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all MaintenanceWindows. You can use a query to get a filtered list of MaintenanceWindows.
@@ -172,14 +186,15 @@ service MaintenanceWindow {
      */
     rpc list (MaintenanceWindowQuery) returns (MaintenanceWindowsInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/maintenance-windows"
-            additional_bindings {
-                post: "/monitoring/v1/maintenance-windows/search"
-            }
+            post: "/monitoring/v1/maintenance-window/list",
+            body: "*"
         };
     }
     rpc stat (MaintenanceWindowStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/maintenance-windows/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/maintenance-window/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/metric.proto
+++ b/proto/spaceone/api/monitoring/v1/metric.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 
@@ -71,7 +73,10 @@ service Metric {
         }
      */
     rpc list (MetricRequest) returns (MetricsInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/data-source/{data_source_id}/metrics" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/metric/list",
+            body: "*"
+        };
     }
     /*
     desc: Gets data of a single Metric. You must specify the parameter `metric` to get data of. You can specify the `period` to get data for.
@@ -132,7 +137,10 @@ service Metric {
         }
      */
     rpc get_data (MetricDataRequest) returns (MetricDataInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/data-source/{data_source_id}/metric-data" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/metric/get-data",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/note.proto
+++ b/proto/spaceone/api/monitoring/v1/note.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -32,7 +34,10 @@ service Note {
         }
      */
     rpc create (CreateNoteRequest) returns (NoteInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/notes" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/note/create",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Note. You must specify the `note_id` for Note validation check. If the Note exists, it is updated.
@@ -54,7 +59,10 @@ service Note {
         }
      */
     rpc update (UpdateNoteRequest) returns (NoteInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/note/{note_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/note/update",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Note. You must specify the `note_id` of the Note to delete.
@@ -65,7 +73,10 @@ service Note {
         }
      */
     rpc delete (NoteRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/monitoring/v1/note/{note_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/note/delete",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Note. You must specify the `note_id` and `domain_id`.
@@ -86,7 +97,10 @@ service Note {
         }
      */
     rpc get (GetNoteRequest) returns (NoteInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/note/{note_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/note/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Notes. You can use a query to get a filtered list of Notes.
@@ -122,14 +136,15 @@ service Note {
      */
     rpc list (NoteQuery) returns (NotesInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/notes"
-            additional_bindings {
-                post: "/monitoring/v1/notes/search"
-            }
+            post: "/monitoring/v1/note/list",
+            body: "*"
         };
     }
     rpc stat (NoteStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/notes/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/note/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/project_alert_config.proto
+++ b/proto/spaceone/api/monitoring/v1/project_alert_config.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -41,7 +43,10 @@ service ProjectAlertConfig {
         }
      */
     rpc create (CreateProjectAlertConfigRequest) returns (ProjectAlertConfigInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/project-alert-configs" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/project-alert-config/create",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific ProjectAlertConfig. You can make changes in ProjectAlertConfig settings, including the EscalationPolicy to apply. You can also change `notification_urgency` and `recovery_mode` by modifying the `options` parameter.
@@ -72,7 +77,10 @@ service ProjectAlertConfig {
         }
      */
     rpc update (UpdateProjectAlertConfigRequest) returns (ProjectAlertConfigInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/project-alert-config/{project_alert_config_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/project-alert-config/update",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific ProjectAlertConfig. Deletes alert configuration data in a Project.
@@ -83,7 +91,10 @@ service ProjectAlertConfig {
         }
      */
     rpc delete (ProjectAlertConfigRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/monitoring/v1/project-alert-config/{project_alert_config_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/project-alert-config/delete",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific ProjectAlertConfig. Prints detailed information about the ProjectAlertConfig, including EscalationPolicy, recovery mode, and notification urgency.
@@ -109,7 +120,10 @@ service ProjectAlertConfig {
         }
      */
     rpc get (GetProjectAlertConfigRequest) returns (ProjectAlertConfigInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/project-alert-config/{project_alert_config_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/project-alert-config/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all ProjectAlertConfigs from all projects configured in the same domain. You can use a query to get a filtered list of ProjectAlertConfigs.
@@ -154,14 +168,15 @@ service ProjectAlertConfig {
      */
     rpc list (ProjectAlertConfigQuery) returns (ProjectAlertConfigsInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/project-alert-configs"
-            additional_bindings {
-                post: "/monitoring/v1/project-alert-configs/search"
-            }
+            post: "/monitoring/v1/project-alert-config/list",
+            body: "*"
         };
     }
     rpc stat (ProjectAlertConfigStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/project-alert-configs/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/project-alert-config/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/monitoring/v1/webhook.proto
+++ b/proto/spaceone/api/monitoring/v1/webhook.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.monitoring.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/monitoring/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -45,7 +47,10 @@ service Webhook {
           }
      */
     rpc create (CreateWebhookRequest) returns (WebhookInfo) {
-        option (google.api.http) = { post: "/monitoring/v1/webhooks" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/create",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Webhook. You can make changes in Webhook settings, including the name and tags.
@@ -76,7 +81,10 @@ service Webhook {
          }
      */
     rpc update (UpdateWebhookRequest) returns (WebhookInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/webhook/{webhook_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/update",
+            body: "*"
+        };
     }
     /*
     desc: Updates the plugin of a specific DataSource. You can change the `version` of the plugin and select the `upgrade_mode` among `AUTO`, `MANUAL`, and `NONE`.
@@ -109,7 +117,10 @@ service Webhook {
          }
      */
     rpc update_plugin (UpdateWebhookPluginRequest) returns (WebhookInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/webhook/{webhook_id}/plugin" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/update-plugin",
+            body: "*"
+        };
     }
     /*
     desc: Verifies a specific plugin for a Webhook.
@@ -120,7 +131,10 @@ service Webhook {
          }
      */
     rpc verify_plugin (WebhookRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { post: "/monitoring/v1/webhook/{webhook_id}/plugin/verify" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/verify-plugin",
+            body: "*"
+        };
     }
     /*
     desc: Enables a specific Webhook. By enabling a Webhook, you can communicate with an external application.
@@ -150,7 +164,10 @@ service Webhook {
          }
      */
     rpc enable (WebhookRequest) returns (WebhookInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/webhook/{webhook_id}/enable" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/enable",
+            body: "*"
+        };
     }
     /*
     desc: Disables a specific Webhook. By disabling a Webhook, you cannot communicate with an external application, as the webhook URL from the Webhook becomes invalid.
@@ -180,7 +197,10 @@ service Webhook {
          }
      */
     rpc disable (WebhookRequest) returns (WebhookInfo) {
-        option (google.api.http) = { put: "/monitoring/v1/webhook/{webhook_id}/disable" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/disable",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Webhook. By deleting a Webhook, you cannot collect data from an external monitoring system, as the `REST URL` is also deleted.
@@ -191,7 +211,10 @@ service Webhook {
          }
      */
     rpc delete (WebhookRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/monitoring/v1/webhook/{webhook_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/delete",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Webhook. Prints detailed information about the Webhook, including the name, the version, and the created datetime.
@@ -221,7 +244,10 @@ service Webhook {
          }
      */
     rpc get (GetWebhookRequest) returns (WebhookInfo) {
-        option (google.api.http) = { get: "/monitoring/v1/webhook/{webhook_id}" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Webhooks. You can use a query to get a filtered list of Webhooks.
@@ -276,14 +302,15 @@ service Webhook {
      */
     rpc list (WebhookQuery) returns (WebhooksInfo) {
         option (google.api.http) = {
-            get: "/monitoring/v1/webhooks"
-            additional_bindings {
-                post: "/monitoring/v1/webhooks/search"
-            }
+            post: "/monitoring/v1/webhook/list",
+            body: "*"
         };
     }
     rpc stat (WebhookStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/monitoring/v1/webhooks/stat" };
+        option (google.api.http) = {
+            post: "/monitoring/v1/webhook/stat",
+            body: "*"
+        };
     }
 }
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
### Description
- modify `monitoring` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate Go code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 

### Known issue