### PR TITLE
Modify secret service http request url at proto file

### DIFF
--- a/proto/spaceone/api/secret/v1/secret.proto
+++ b/proto/spaceone/api/secret/v1/secret.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.secret.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/secret/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -39,7 +41,10 @@ service Secret {
         }
      */
     rpc create (CreateSecretRequest) returns (SecretInfo) {
-        option (google.api.http) = { post: "/secret/v1/secrets" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Secret. You can make changes in Secret settings, including `name` and`tags`.
@@ -67,7 +72,10 @@ service Secret {
         }
      */
     rpc update (UpdateSecretRequest) returns (SecretInfo) {
-        option (google.api.http) = { put: "/secret/v1/secret/{secret_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret/update"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Secret. You must specify the `secret_id` of the Secret to delete.
@@ -78,7 +86,10 @@ service Secret {
         }
      */
     rpc delete (SecretRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/secret/v1/secret/{secret_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret/delete"
+            body: "*"
+        };
     }
     /*
     desc: Updates encrypted data of a specific Secret resource. For example, to change the parameter `data`, external data to encrypt, you can use `update_data` to create new encrypted data based on the changed `data` and store it in the Secret resource.
@@ -101,7 +112,10 @@ service Secret {
         }
      */
     rpc update_data (UpdateSecretDataRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { put: "/secret/v1/secret/{secret_id}/data" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret/update-data"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Secret. Prints detailed information about the Secret, including  `name`, `tags`, `schema`, and `provider`.
@@ -123,7 +137,10 @@ service Secret {
         }
      */
     rpc get_data (SecretRequest) returns (SecretDataInfo) {
-        option (google.api.http) = { get: "/secret/v1/secret/{secret_id}/data" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret/get-data"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Post. You must specify the `post_id` of the Post to get, and the `board_id` of the Board where the child Post to get belongs. Prints detailed information about the Post.
@@ -147,7 +164,10 @@ service Secret {
         }
      */
     rpc get (GetSecretRequest) returns (SecretInfo) {
-        option (google.api.http) = { get: "/secret/v1/secret/{secret_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Posts. You can use a query to get a filtered list of Posts.
@@ -185,14 +205,15 @@ service Secret {
      */
     rpc list (SecretQuery) returns (SecretsInfo) {
         option (google.api.http) = {
-            get: "/secret/v1/secrets"
-            additional_bindings {
-                post: "/secret/v1/secrets/search"
-            }
+            post: "/secret/v1/secret/list"
+            body: "*"
         };
     }
     rpc stat (SecretStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/secret/v1/secrets/stat" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret/stat"
+            body: "*"
+        };
     }
 }
 
@@ -274,7 +295,7 @@ message SecretQuery {
     // is_required: false
     SecretType secret_type = 4;
     // is_required: false
-    string schema= 6;
+    string schema = 6;
     // is_required: false
     string provider = 7;
     // is_required: false

--- a/proto/spaceone/api/secret/v1/secret_group.proto
+++ b/proto/spaceone/api/secret/v1/secret_group.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package spaceone.api.secret.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/secret/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -11,33 +13,52 @@ import "spaceone/api/secret/v1/secret.proto";
 
 service SecretGroup {
     rpc create (CreateSecretGroupRequest) returns (SecretGroupInfo) {
-        option (google.api.http) = { post: "/secret/v1/secret-groups" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret-group/create"
+            body: "*"
+        };
     }
     rpc update (UpdateSecretGroupRequest) returns (SecretGroupInfo) {
-        option (google.api.http) = { put: "/secret/v1/secret-group/{secret_group_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret-group/update"
+            body: "*"
+        };
     }
     rpc add_secret (SecretGroupSecretRequest) returns (SecretGroupSecretInfo) {
-        option (google.api.http) = { post: "/secret/v1/secret-group/{secret_group_id}/secrets" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret-group/add-secret"
+            body: "*"
+        };
     }
     rpc remove_secret (SecretGroupSecretRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/secret/v1/secret-group/{secret_group_id}/secret/{secret_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret-group/remove-secret"
+            body: "*"
+        };
     }
     rpc delete (SecretGroupRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/secret/v1/secret-group/{secret_group_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret-group/delete"
+            body: "*"
+        };
     }
     rpc get (GetSecretGroupRequest) returns (SecretGroupInfo) {
-        option (google.api.http) = { get: "/secret/v1/secret-group/{secret_group_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret-group/get"
+            body: "*"
+        };
     }
     rpc list (SecretGroupQuery) returns (SecretGroupsInfo) {
         option (google.api.http) = {
-            get: "/secret/v1/secret-groups"
-            additional_bindings {
-                post: "/secret/v1/secret-groups/search"
-            }
+            post: "/secret/v1/secret-group/list"
+            body: "*"
         };
     }
     rpc stat (SecretGroupStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/secret/v1/secret-groups/stat" };
+        option (google.api.http) = {
+            post: "/secret/v1/secret-group/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/secret/v1/trusted_secret.proto
+++ b/proto/spaceone/api/secret/v1/trusted_secret.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.secret.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/secret/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -36,7 +38,10 @@ service TrustedSecret {
         }
      */
     rpc create (CreateTrustedSecretRequest) returns (TrustedSecretInfo) {
-        option (google.api.http) = { post: "/secret/v1/trusted-secrets" };
+        option (google.api.http) = {
+            post: "/secret/v1/trusted-secret/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Secret. You can make changes in Secret settings, including `name` and`tags`.
@@ -60,7 +65,10 @@ service TrustedSecret {
         }
      */
     rpc update (UpdateTrustedSecretRequest) returns (TrustedSecretInfo) {
-        option (google.api.http) = { put: "/secret/v1/trusted-secret/{trusted_secret_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/trusted-secret/update"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Secret. You must specify the `secret_id` of the Secret to delete.
@@ -71,7 +79,10 @@ service TrustedSecret {
         }
      */
     rpc delete (TrustedSecretRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/secret/v1/trusted-secret/{trusted_secret_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/trusted-secret/delete"
+            body: "*"
+        };
     }
     /*
     desc: Updates encrypted data of a specific Secret resource. For example, to change the parameter `data`, external data to encrypt, you can use `update_data` to create new encrypted data based on the changed `data` and store it in the Secret resource.
@@ -94,7 +105,10 @@ service TrustedSecret {
         }
      */
     rpc update_data (UpdateTrustedSecretDataRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { put: "/secret/v1/trusted-secret/{trusted_secret_id}/data" };
+        option (google.api.http) = {
+            post: "/secret/v1/trusted-secret/update-data"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Post. You must specify the `post_id` of the Post to get, and the `board_id` of the Board where the child Post to get belongs. Prints detailed information about the Post.
@@ -116,7 +130,10 @@ service TrustedSecret {
         }
      */
     rpc get (GetTrustedSecretRequest) returns (TrustedSecretInfo) {
-        option (google.api.http) = { get: "/secret/v1/trusted-secret/{trusted_secret_id}" };
+        option (google.api.http) = {
+            post: "/secret/v1/trusted-secret/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Posts. You can use a query to get a filtered list of Posts.
@@ -151,14 +168,15 @@ service TrustedSecret {
      */
     rpc list (TrustedSecretQuery) returns (TrustedSecretsInfo) {
         option (google.api.http) = {
-            get: "/secret/v1/trusted-secrets"
-            additional_bindings {
-                post: "/secret/v1/trusted-secrets/search"
-            }
+            post: "/secret/v1/trusted-secret/list"
+            body: "*"
         };
     }
     rpc stat (TrustedSecretStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/secret/v1/trusted-secrets/stat" };
+        option (google.api.http) = {
+            post: "/secret/v1/trusted-secret/stat"
+            body: "*"
+        };
     }
 }
 
@@ -225,7 +243,7 @@ message TrustedSecretQuery {
     /// is_required: false
     string name = 3;
     // is_required: false
-    string schema= 6;
+    string schema = 6;
     // is_required: false
     string provider = 7;
     // is_required: false


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- modify `secret` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate Go code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 


### Known issue