### PR TITLE
Modify cost-analysis service http request url at proto file

### DIFF
--- a/proto/spaceone/api/cost_analysis/plugin/cost.proto
+++ b/proto/spaceone/api/cost_analysis/plugin/cost.proto
@@ -1,6 +1,9 @@
 syntax = "proto3";
 
 package spaceone.api.cost_analysis.plugin;
+
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/plugin";
+
 import "google/protobuf/struct.proto";
 
 

--- a/proto/spaceone/api/cost_analysis/plugin/data_source.proto
+++ b/proto/spaceone/api/cost_analysis/plugin/data_source.proto
@@ -1,6 +1,9 @@
 syntax = "proto3";
 
 package spaceone.api.cost_analysis.plugin;
+
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/plugin";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 

--- a/proto/spaceone/api/cost_analysis/plugin/job.proto
+++ b/proto/spaceone/api/cost_analysis/plugin/job.proto
@@ -1,6 +1,9 @@
 syntax = "proto3";
 
 package spaceone.api.cost_analysis.plugin;
+
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/plugin";
+
 import "google/protobuf/struct.proto";
 
 

--- a/proto/spaceone/api/cost_analysis/v1/budget.proto
+++ b/proto/spaceone/api/cost_analysis/v1/budget.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -101,7 +103,10 @@ service Budget {
       }
     */
     rpc create (CreateBudgetRequest) returns (BudgetInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/budgets" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Budget. You can make changes in the budgeted amount of the time period specified while creating the resource.
@@ -176,7 +181,10 @@ service Budget {
       }
     */
     rpc update (UpdateBudgetRequest) returns (BudgetInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/budget/{budget_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget/update"
+            body: "*"
+        };
     }
     /*
     desc: Sets a notification on a specific Budget. Sets a threshold on the budget, and if the cost exceeds the threshold, a notification is raised.
@@ -224,7 +232,10 @@ service Budget {
       }
     */
     rpc set_notification (SetBudgetNotificationRequest) returns (BudgetInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/budget/{budget_id}/notification" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget/set-notification"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Budget. You must specify the `budget_id` of the Budget to delete.
@@ -234,7 +245,10 @@ service Budget {
       }
     */
     rpc delete (BudgetRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/budget/{budget_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Budget. Prints detailed information about the Budget, including `planned_limits` of the project group or project for the pre-defined period.
@@ -309,7 +323,10 @@ service Budget {
       }
     */
     rpc get (GetBudgetRequest) returns (BudgetInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/budget/{budget_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Budgets. You can use a query to get a filtered list of Budgets.
@@ -390,14 +407,15 @@ service Budget {
     */
     rpc list (BudgetQuery) returns (BudgetsInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/budgets"
-            additional_bindings {
-                post: "/cost-analysis/v1/budgets/search"
-            }
+            post: "/cost-analysis/v1/budget/list"
+            body: "*"
         };
     }
     rpc stat (BudgetStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/budgets/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/budget_usage.proto
+++ b/proto/spaceone/api/cost_analysis/v1/budget_usage.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "spaceone/api/core/v1/query.proto";
@@ -41,17 +43,21 @@ service BudgetUsage {
     */
     rpc list (BudgetUsageQuery) returns (BudgetUsagesInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/budget/{budget_id}/usage"
-            additional_bindings {
-                post: "/cost-analysis/v1/budget/{budget_id}/usage/search"
-            }
+            post: "/cost-analysis/v1/budget-usage/list"
+            body: "*"
         };
     }
     rpc analyze (BudgetUsageAnalyzeQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/budget/{budget_id}/usage/analyze" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget-usage/analyze"
+            body: "*"
+        };
     }
     rpc stat (BudgetUsageStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/budget/{budget_id}/usage/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/budget-usage/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/cost.proto
+++ b/proto/spaceone/api/cost_analysis/v1/cost.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -53,7 +55,10 @@ service Cost {
       }
     */
     rpc create (CreateCostRequest) returns (CostInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/costs" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost/create"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Cost. You must specify the `cost_id` of the Cost to delete.
@@ -63,7 +68,10 @@ service Cost {
       }
     */
     rpc delete (CostRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/cost/{cost_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Cost. Prints detailed information about the Cost, including  `region_code` and `account`.
@@ -94,7 +102,10 @@ service Cost {
       }
     */
     rpc get (GetCostRequest) returns (CostInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/cost/{cost_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Costs. You can use a query to get a filtered list of Costs.
@@ -150,10 +161,8 @@ service Cost {
     */
     rpc list (CostQuery) returns (CostsInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/costs"
-            additional_bindings {
-                post: "/cost-analysis/v1/costs/search"
-            }
+            post: "/cost-analysis/v1/cost/list"
+            body: "*"
         };
     }
     /*
@@ -203,13 +212,22 @@ service Cost {
       }
     */
     rpc analyze (CostAnalyzeQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/costs/analyze" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost/analyze"
+            body: "*"
+        };
     }
     rpc analyze_v2 (CostAnalyzeV2Query) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/costs/analyze-v2" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost/analyze-v2"
+            body: "*"
+        };
     }
     rpc stat (CostStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/costs/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/cost_query_set.proto
+++ b/proto/spaceone/api/cost_analysis/v1/cost_query_set.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -59,7 +61,10 @@ service CostQuerySet {
       }
     */
     rpc create (CreateCostQuerySetRequest) returns (CostQuerySetInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/cost-query-sets" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost-query-set/create",
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific CostQuerySet. You can make changes in the details of queries.
@@ -111,7 +116,10 @@ service CostQuerySet {
       }
     */
     rpc update (UpdateCostQuerySetRequest) returns (CostQuerySetInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/cost-query-set/{cost_query_set_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost-query-set/update",
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific CostQuerySet. You must specify the `cost_query_set_id` of the CostQuerySet to delete.
@@ -121,7 +129,10 @@ service CostQuerySet {
       }
     */
     rpc delete (CostQuerySetRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/cost-query-set/{cost_query_set_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost-query-set/delete",
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific CostQuerySet. Prints detailed information about the CostQuerySet, including the details of queries.
@@ -154,7 +165,10 @@ service CostQuerySet {
       }
     */
     rpc get (GetCostQuerySetRequest) returns (CostQuerySetInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/cost-query-set/{cost_query_set_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost-query-set/get",
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all CostQuerySets. You can use a query to get a filtered list of CostQuerySets.
@@ -215,14 +229,15 @@ service CostQuerySet {
     */
     rpc list (CostQuerySetQuery) returns (CostQuerySetsInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/cost-query-sets"
-            additional_bindings {
-                post: "/cost-analysis/v1/cost-query-sets/search"
-            }
+            post: "/cost-analysis/v1/cost-query-sets/list",
+            body: "*"
         };
     }
     rpc stat (CostQuerySetStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/cost-query-sets/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/cost-query-sets/stat",
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/custom_widget.proto
+++ b/proto/spaceone/api/cost_analysis/v1/custom_widget.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -46,7 +48,10 @@ service CustomWidget {
       }
     */
     rpc create (CreateCustomWidgetRequest) returns (CustomWidgetInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/custom-widgets" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/custom-widget/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific CustomWidget. You can make changes in CustomWidget settings, including `chart_type` and queries.
@@ -88,7 +93,10 @@ service CustomWidget {
       }
     */
     rpc update (UpdateCustomWidgetRequest) returns (CustomWidgetInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/custom-widget/{widget_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/custom-widget/update"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific CustomWidget. You must specify the `custom_widget_id` of the CustomWidget to delete.
@@ -98,7 +106,10 @@ service CustomWidget {
       }
     */
     rpc delete (CustomWidgetRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/custom-widget/{widget_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/custom-widget/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific CustomWidget. Prints detailed information about the CustomWidget, including `chart_type` and queries.
@@ -126,7 +137,10 @@ service CustomWidget {
       }
     */
     rpc get (GetCustomWidgetRequest) returns (CustomWidgetInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/custom-widget/{widget_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/custom-widget/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all CustomWidgets. You can use a query to get a filtered list of CustomWidgets.
@@ -177,14 +191,15 @@ service CustomWidget {
     */
     rpc list (CustomWidgetQuery) returns (CustomWidgetsInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/custom-widgets"
-            additional_bindings {
-                post: "/cost-analysis/v1/custom-widgets/search"
-            }
+            post: "/cost-analysis/v1/custom-widget/list"
+            body: "*"
         };
     }
     rpc stat (CustomWidgetStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/custom-widgets/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/custom-widget/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/data_source.proto
+++ b/proto/spaceone/api/cost_analysis/v1/data_source.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -99,7 +101,10 @@ service DataSource {
       }
     */
     rpc register (RegisterDataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/data-sources" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/register"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific DataSource. You can make changes in DataSource settings, including `name` and `tags`.
@@ -161,7 +166,10 @@ service DataSource {
       }
     */
     rpc update (UpdateDataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/data-source/{data_source_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/update"
+            body: "*"
+        };
     }
     /*
     desc: Updates the plugin of a specific DataSource. This method resets the plugin data in the DataSource to update the `metadata`.
@@ -222,7 +230,10 @@ service DataSource {
       }
     */
     rpc update_plugin (UpdateDataSourcePluginRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/data-source/{data_source_id}/plugin" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/update-plugin"
+            body: "*"
+        };
     }
     /*
     desc: Verifies the plugin of a specific DataSource. This method validates the plugin data, `version` and `endpoint`.
@@ -232,7 +243,10 @@ service DataSource {
       }
     */
     rpc verify_plugin (DataSourceRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { post: "/cost-analysis/v1/data-source/{data_source_id}/plugin/verify" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/verify-plugin"
+            body: "*"
+        };
     }
     /*
     desc: Enables a specific DataSource. By enabling a DataSource, you can communicate with an external cloud service via the plugin.
@@ -290,7 +304,10 @@ service DataSource {
       }
     */
     rpc enable (DataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/data-source/{data_source_id}/enable" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/enable"
+            body: "*"
+        };
     }
     /*
     desc: Disables a specific DataSource. By disabling a DataSource, you can block communication with an external cloud service via the plugin.
@@ -348,7 +365,10 @@ service DataSource {
       }
     */
     rpc disable (DataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/data-source/{data_source_id}/disable" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/disable"
+            body: "*"
+        };
     }
     /*
     desc: Deregisters and deletes a specific DataSource. You must specify the `data_source_id` of the DataSource to deregister.
@@ -358,7 +378,10 @@ service DataSource {
       }
     */
     rpc deregister (DataSourceRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/data-source/{data_source_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/deregister"
+            body: "*"
+        };
     }
     /*
     desc: Manually runs a specific DataSource to collect the cost data. This method is to get up-to-date cost data.
@@ -388,7 +411,10 @@ service DataSource {
       }
     */
     rpc sync (SyncDataSourceRequest) returns (spaceone.api.cost_analysis.v1.JobInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/data-source/{data_source_id}/sync" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/sync"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific DataSource. Prints detailed information about the DataSource, including `name`, `state`, and `plugin_info`.
@@ -447,7 +473,10 @@ service DataSource {
       }
     */
     rpc get (GetDataSourceRequest) returns (DataSourceInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/data-source/{data_source_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all DataSources. You can use a query to get a filtered list of DataSources.
@@ -551,14 +580,15 @@ service DataSource {
     */
     rpc list (DataSourceQuery) returns (DataSourcesInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/data-sources"
-            additional_bindings {
-                post: "/cost-analysis/v1/data-sources/search"
-            }
+            post: "/cost-analysis/v1/data-source/list"
+            body: "*"
         };
     }
     rpc stat (DataSourceStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/data-sources/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/data_source_rule.proto
+++ b/proto/spaceone/api/cost_analysis/v1/data_source_rule.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -50,7 +52,10 @@ service DataSourceRule {
       }
     */
     rpc create (CreateDataSourceRuleRequest) returns (DataSourceRuleInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/data_source_rules" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source-rule/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific DataSourceRule. You can make changes in DataSourceRule settings, including filtering conditions. If the parameter `is_default` is `true`, only `Admin` type User can use this method.
@@ -95,7 +100,10 @@ service DataSourceRule {
       }
     */
     rpc update (UpdateDataSourceRuleRequest) returns (DataSourceRuleInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/data_source_rule/{data_source_rule_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source-rule/update"
+            body: "*"
+        };
     }
     /*
     desc: Changes the priority order of the DataSourceRules to apply. If there are multiple DataSourceRules applied in a specific service account, the priority order of the resources is requried. This method changes the priority order to apply DataSourceRules.
@@ -129,7 +137,10 @@ service DataSourceRule {
       }
     */
     rpc change_order (ChangeDataSourceRuleOrderRequest) returns (DataSourceRuleInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/data_source_rule/{data_source_rule_id}/order" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source-rule/change-order"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific DataSourceRule. You must specify the `data_source_rule_id` of the DataSourceRule to delete. If the parameter `is_default` is `true`, only `Admin` type User can use this method.
@@ -139,7 +150,10 @@ service DataSourceRule {
       }
     */
     rpc delete (DataSourceRuleRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/data_source_rule/{data_source_rule_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source-rule/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific DataSourceRule. Prints detailed information about the DataSourceRule, including  `conditions_policy` and conditions applied to DataSources.
@@ -169,7 +183,10 @@ service DataSourceRule {
       }
     */
     rpc get (GetDataSourceRuleRequest) returns (DataSourceRuleInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/data_source_rule/{data_source_rule_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source-rule/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all DataSourceRules. You can use a query to get a filtered list of DataSourceRules.
@@ -224,14 +241,15 @@ service DataSourceRule {
     */
     rpc list (DataSourceRuleQuery) returns (DataSourceRulesInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/data_source_rules"
-            additional_bindings {
-                post: "/cost-analysis/v1/data_source_rules/search"
-            }
+            post: "/cost-analysis/v1/data-source-rule/list"
+            body: "*"
         };
     }
     rpc stat (DataSourceRuleStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/data_source_rules/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/data-source-rule/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/exchange_rate.proto
+++ b/proto/spaceone/api/cost_analysis/v1/exchange_rate.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/api/annotations.proto";
 
 
@@ -25,7 +27,10 @@ service ExchangeRate {
       }
     */
     rpc set (SetExchangeRateRequest) returns (ExchangeRateInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/exchange-rate/{currency}/set" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/exchange-rate/set"
+            body: "*"
+        };
     }
     /*
     desc: Resets a value of a specific ExchangeRate and changes the ExchangeRate to the ExchangeRate of the `default` domain.
@@ -43,7 +48,10 @@ service ExchangeRate {
       }
     */
     rpc reset (ExchangeRateRequest) returns (ExchangeRateInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/exchange-rate/{currency}/reset" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/exchange-rate/reset"
+            body: "*"
+        };
     }
     /*
     desc: ''
@@ -56,7 +64,10 @@ service ExchangeRate {
       }
     */
     rpc enable (ExchangeRateRequest) returns (ExchangeRateInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/exchange-rate/{currency}/enable" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/exchange-rate/enable"
+            body: "*"
+        };
     }
     /*
     desc: ''
@@ -70,7 +81,10 @@ service ExchangeRate {
       }
     */
     rpc disable (ExchangeRateRequest) returns (ExchangeRateInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/exchange-rate/{currency}/disable" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/exchange-rate/disable"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific ExchangeRate. Prints detailed information about the ExchangeRate, including  `currency` and `rate`.
@@ -88,7 +102,10 @@ service ExchangeRate {
       }
     */
     rpc get (ExchangeRateRequest) returns (ExchangeRateInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/exchange-rate/{currency}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/exchange-rate/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all ExchangeRates. You can use a query to get a filtered list of ExchangeRates.
@@ -118,10 +135,8 @@ service ExchangeRate {
     */
     rpc list (ExchangeRateQuery) returns (ExchangeRatesInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/exchange-rates"
-            additional_bindings {
-                post: "/cost-analysis/v1/exchange-rates/search"
-            }
+            post: "/cost-analysis/v1/exchange-rate/list"
+            body: "*"
         };
     }
 }

--- a/proto/spaceone/api/cost_analysis/v1/job.proto
+++ b/proto/spaceone/api/cost_analysis/v1/job.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "spaceone/api/core/v1/query.proto";
@@ -40,7 +42,10 @@ service Job {
       }
     */
     rpc cancel (JobRequest) returns (JobInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/job/{job_id}/cancel" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/job/cancel"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Job. Prints detailed information about the Job, including the plugin used, operation time, and `status`.
@@ -70,7 +75,10 @@ service Job {
       }
     */
     rpc get (GetJobRequest) returns (JobInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/job/{job_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/job/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Jobs. You can use a query to get a filtered list of Jobs.
@@ -125,14 +133,15 @@ service Job {
     */
     rpc list (JobQuery) returns (JobsInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/jobs"
-            additional_bindings {
-                post: "/cost-analysis/v1/jobs/search"
-            }
+            post: "/cost-analysis/v1/job/list"
+            body: "*"
         };
     }
     rpc stat (JobStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/jobs/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/job/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/job_task.proto
+++ b/proto/spaceone/api/cost_analysis/v1/job_task.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "spaceone/api/core/v1/query.proto";
@@ -36,7 +38,10 @@ service JobTask {
       }
     */
     rpc get (GetJobTaskRequest) returns (JobTaskInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/job-task/{job_task_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/job-task/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all JobTasks. You can use a query to get a filtered list of JobTasks.
@@ -85,14 +90,15 @@ service JobTask {
     */
     rpc list (JobTaskQuery) returns (JobTasksInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/job-tasks"
-            additional_bindings {
-                post: "/cost-analysis/v1/job-tasks/search"
-            }
+            post: "/cost-analysis/v1/job-task/list"
+            body: "*"
         };
     }
     rpc stat (JobTaskStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/job-tasks/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/job-task/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/public_dashboard.proto
+++ b/proto/spaceone/api/cost_analysis/v1/public_dashboard.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -110,7 +112,10 @@ service PublicDashboard {
       }
     */
     rpc create (CreatePublicDashboardRequest) returns (PublicDashboardInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/public-dashboards" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/public-dashboard/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific PublicDashboard. Changes the widgets of the PublicDashboard with default widgets and customized widgets. Only `Admin` type Users can use the method.
@@ -210,7 +215,10 @@ service PublicDashboard {
       }
     */
     rpc update (UpdatePublicDashboardRequest) returns (PublicDashboardInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/public-dashboard/{public_dashboard_id}" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/public-dashboard/update"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific PublicDashboard. You must specify the `public_dashboard_id` of the PublicDashboard to delete.
@@ -220,7 +228,10 @@ service PublicDashboard {
       }
     */
     rpc delete (PublicDashboardRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/public-dashboard/{public_dashboard_id}" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/public-dashboard/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific PublicDashboard. Prints detailed information about the PublicDashboard, including `custom_layouts` and `period_type`.
@@ -284,7 +295,10 @@ service PublicDashboard {
       }
     */
     rpc get (GetPublicDashboardRequest) returns (PublicDashboardInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/public-dashboard/{public_dashboard_id}" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/public-dashboard/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all PublicDashboards. You can use a query to get a filtered list of PublicDashboards.
@@ -456,14 +470,15 @@ service PublicDashboard {
     */
     rpc list (PublicDashboardQuery) returns (PublicDashboardsInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/public-dashboards"
-            additional_bindings {
-                post: "/cost-analysis/v1/public-dashboards/search"
-            }
+            post: "/cost-analysis/v1/public-dashboard/list"
+            body: "*"
         };
     }
     rpc stat (PublicDashboardStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/public-dashboards/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/public-dashboard/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/schedule.proto
+++ b/proto/spaceone/api/cost_analysis/v1/schedule.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -10,33 +12,52 @@ import "spaceone/api/core/v1/query.proto";
 
 service Schedule {
     rpc create (CreateScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/schedules" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/schedule/create"
+            body: "*"
+        };
     }
     rpc update (UpdateScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/schedule/{schedule_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/schedule/update"
+            body: "*"
+        };
     }
     rpc enable (ScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/schedule/{schedule_id}/enable" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/schedule/enable"
+            body: "*"
+        };
     }
     rpc disable (ScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/schedule/{schedule_id}/disable" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/schedule/disable"
+            body: "*"
+        };
     }
     rpc delete (ScheduleRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/schedule/{schedule_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/schedule/delete"
+            body: "*"
+        };
     }
     rpc get (GetScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/schedule/{schedule_id}" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/schedule/get"
+            body: "*"
+        };
     }
     rpc list (ScheduleQuery) returns (SchedulesInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/schedules"
-            additional_bindings {
-                post: "/cost-analysis/v1/schedules/search"
-            }
+            post: "/cost-analysis/v1/schedule/list"
+            body: "*"
         };
     }
     rpc stat (ScheduleStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/schedules/stat" };
+        option (google.api.http) = {
+            post: "/cost-analysis/v1/schedule/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/cost_analysis/v1/user_dashboard.proto
+++ b/proto/spaceone/api/cost_analysis/v1/user_dashboard.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.cost_analysis.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/cost_analysis/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -112,7 +114,10 @@ service UserDashboard {
       }
     */
     rpc create (CreateUserDashboardRequest) returns (UserDashboardInfo) {
-        option (google.api.http) = { post: "/cost-analysis/v1/user-dashboards" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/user-dashboard/create"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific UserDashboard. You can make changes in widgets, including default widgets and CustomWidegets.
@@ -200,7 +205,10 @@ service UserDashboard {
       }
     */
     rpc update (UpdateUserDashboardRequest) returns (UserDashboardInfo) {
-        option (google.api.http) = { put: "/cost-analysis/v1/user-dashboard/{user_dashboard_id}" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/user-dashboard/update"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific UserDashboard. You must specify the `user_dashboard_id` of the UserDashboard to delete.
@@ -210,7 +218,10 @@ service UserDashboard {
       }
     */
     rpc delete (UserDashboardRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/cost-analysis/v1/user-dashboard/{user_dashboard_id}" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/user-dashboard/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific UserDashboard. Prints detailed information about the UserDashboard, including widegts used.
@@ -271,7 +282,10 @@ service UserDashboard {
       }
     */
     rpc get (GetUserDashboardRequest) returns (UserDashboardInfo) {
-        option (google.api.http) = { get: "/cost-analysis/v1/user-dashboard/{user_dashboard_id}" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/user-dashboard/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all UserDashboards. You can use a query to get a filtered list of UserDashboards.
@@ -386,14 +400,15 @@ service UserDashboard {
     */
     rpc list (UserDashboardQuery) returns (UserDashboardsInfo) {
         option (google.api.http) = {
-            get: "/cost-analysis/v1/user-dashboards"
-            additional_bindings {
-                post: "/cost-analysis/v1/user-dashboards/search"
-            }
+            post: "cost-analysis/v1/user-dashboard/list"
+            body: "*"
         };
     }
     rpc stat (UserDashboardStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/cost-analysis/v1/user-dashboards/stat" };
+        option (google.api.http) = {
+            post: "cost-analysis/v1/user-dashboard/stat"
+            body: "*"
+        };
     }
 }
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- modify `cost-analysis` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate Go code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 

### Known issue