### PR TITLE
Modify statistics service http request url at proto file

### DIFF
--- a/proto/spaceone/api/statistics/plugin/storage.proto
+++ b/proto/spaceone/api/statistics/plugin/storage.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package spaceone.api.inventory.plugin;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/statistics/plugin";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 

--- a/proto/spaceone/api/statistics/v1/history.proto
+++ b/proto/spaceone/api/statistics/v1/history.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.statistics.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/statistics/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -21,7 +23,10 @@ service History {
         }
      */
     rpc create (CreateHistoryRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { post: "/statistics/v1/history" };
+        option (google.api.http) = {
+            post: "/statistics/v1/history/create"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Histories. You can use a query to get a filtered list of Histories.
@@ -65,14 +70,15 @@ service History {
      */
     rpc list (QueryHistoryRequest) returns (HistoryInfo) {
         option (google.api.http) = {
-            get: "/statistics/v1/history"
-            additional_bindings {
-                post: "/statistics/v1/history/query"
-            }
+            post: "/statistics/v1/history/list"
+            body: "*"
         };
     }
     rpc stat (HistoryStatRequest) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/statistics/v1/history/stat" };
+        option (google.api.http) = {
+            post: "/statistics/v1/history/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/statistics/v1/resource.proto
+++ b/proto/spaceone/api/statistics/v1/resource.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.statistics.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/statistics/v1";
+
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "spaceone/api/core/v1/query.proto";
@@ -158,7 +160,10 @@ service Resource {
         }
      */
     rpc stat (ResourceStatRequest) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/statistics/v1/resources/stat" };
+        option (google.api.http) = {
+            post: "statistics/v1/resource/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/statistics/v1/schedule.proto
+++ b/proto/spaceone/api/statistics/v1/schedule.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.statistics.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/statistics/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -627,7 +629,10 @@ service Schedule {
         }
      */
     rpc add (AddScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { post: "/statistics/v1/schedules" };
+        option (google.api.http) = {
+            post: "statistics/v1/schedule/add"
+            body: "*"
+        };
     }
     /*
     desc: Updates a specific Schedule. You can make changes in Schedule settings, including time intervals.
@@ -1072,7 +1077,10 @@ service Schedule {
         }
      */
     rpc update (UpdateScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { put: "/statistics/v1/schedule/{schedule_id}" };
+        option (google.api.http) = {
+            post: "/statistics/schedule/update"
+            body: "*"
+        };
     }
     /*
     desc: Enables a specific Schedule. If a Schedule is enabled, the query usage will be scheduled by the time interval specified.
@@ -1515,7 +1523,10 @@ service Schedule {
         }
      */
     rpc enable (ScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { put: "/statistics/v1/schedule/{schedule_id}/enable" };
+        option (google.api.http) = {
+            post: "/statistics/v1/schedule/enable"
+            body: "*"
+        };
     }
     /*
     desc: Disables a specific Schedule. If a Schedule is disabled, the query usage will not be scheduled.
@@ -1958,7 +1969,10 @@ service Schedule {
         }
      */
     rpc disable (ScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { put: "/statistics/v1/schedule/{schedule_id}/disable" };
+        option (google.api.http) = {
+            post: "/statistics/v1/schedule/disable"
+            body: "*"
+        };
     }
     /*
     desc: Deletes a specific Schedule. You must specify the `schedule_id` of the Schedule to delete.
@@ -1969,7 +1983,10 @@ service Schedule {
         }
      */
     rpc delete (ScheduleRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/statistics/v1/schedule/{schedule_id}" };
+        option (google.api.http) = {
+            post: "/statistics/v1/schedule/delete"
+            body: "*"
+        };
     }
     /*
     desc: Gets a specific Schedule. Prints detailed information about the Schedule, including the schedule interval and `state`.
@@ -2410,7 +2427,10 @@ service Schedule {
         }
      */
     rpc get (GetScheduleRequest) returns (ScheduleInfo) {
-        option (google.api.http) = { get: "/statistics/v1/schedule/{schedule_id}" };
+        option (google.api.http) = {
+            post: "statistics/v1/schedule/get"
+            body: "*"
+        };
     }
     /*
     desc: Gets a list of all Schedules. You can use a query to get a filtered list of Schedules.
@@ -2857,14 +2877,15 @@ service Schedule {
      */
     rpc list (ScheduleQuery) returns (SchedulesInfo) {
         option (google.api.http) = {
-            get: "/statistics/v1/schedules"
-            additional_bindings {
-                post: "/statistics/v1/schedules/search"
-            }
+            post: "/statistics/v1/schedule/list"
+            body: "*"
         };
     }
     rpc stat (ScheduleStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/statistics/v1/schedules/stat" };
+        option (google.api.http) = {
+            post: "/statistics/v1/schedule/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/statistics/v1/storage.proto
+++ b/proto/spaceone/api/statistics/v1/storage.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package spaceone.api.statistics.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/statistics/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -11,39 +13,64 @@ import "spaceone/api/statistics/v1/resource.proto";
 
 service Storage {
     rpc register (RegisterStorageRequest) returns (StorageInfo) {
-        option (google.api.http) = { post: "/statistics/v1/storages" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/register"
+            body: "*"
+        };
     }
     rpc update (UpdateStorageRequest) returns (StorageInfo) {
-        option (google.api.http) = { put: "/statistics/v1/storage/{storage_id}" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/update"
+            body: "*"
+        };
     }
     rpc update_plugin (UpdateStoragePluginRequest) returns (StorageInfo) {
-        option (google.api.http) = { put: "/spot-automation/v1/storage/{storage_id}/plugin" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/update-plugin"
+            body: "*"
+        };
     }
     rpc verify_plugin (StorageRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { post: "/spot-automation/v1/storage/{storage_id}/plugin/verify" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/verify-plugin"
+            body: "*"
+        };
     }
     rpc enable (StorageRequest) returns (StorageInfo) {
-        option (google.api.http) = { put: "/statistics/v1/storage/{schedule_id}/enable" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/enable"
+            body: "*"
+        };
     }
     rpc disable (StorageRequest) returns (StorageInfo) {
-        option (google.api.http) = { put: "/statistics/v1/storage/{schedule_id}/disable" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/disable"
+            body: "*"
+        };
     }
     rpc deregister (StorageRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/statistics/v1/storage/{schedule_id}" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/deregister"
+            body: "*"
+        };
     }
     rpc get (GetStorageRequest) returns (StorageInfo) {
-        option (google.api.http) = { get: "/statistics/v1/storage/{schedule_id}" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/get"
+            body: "*"
+        };
     }
     rpc list (StorageQuery) returns (StoragesInfo) {
         option (google.api.http) = {
-            get: "/statistics/v1/storages"
-            additional_bindings {
-                post: "/statistics/v1/storages/search"
-            }
+            post: "/statistics/v1/storage/list"
+            body: "*"
         };
     }
     rpc stat (StorageStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/statistics/v1/storages/stat" };
+        option (google.api.http) = {
+            post: "/statistics/v1/storage/stat"
+            body: "*"
+        };
     }
 }
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- modify `statistics` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate Go code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 

### Known issue