### PR TITLE
Modify config service http request url at proto file

### DIFF
--- a/proto/spaceone/api/config/v1/domain_config.proto
+++ b/proto/spaceone/api/config/v1/domain_config.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.config.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/config/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -13,30 +15,46 @@ import "spaceone/api/core/v1/query.proto";
 
 service DomainConfig {
     rpc create (SetDomainConfigRequest) returns (DomainConfigInfo) {
-        option (google.api.http) = { post: "/config/v1/domain-configs" };
+        option (google.api.http) = {
+            post: "/config/v1/domain-config/create"
+            body: "*"
+        };
     }
     rpc update (SetDomainConfigRequest) returns (DomainConfigInfo) {
-        option (google.api.http) = { put: "/config/v1/domain-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/domain-config/update"
+            body: "*"
+        };
     }
     rpc set (SetDomainConfigRequest) returns (DomainConfigInfo) {
-        option (google.api.http) = { post: "/config/v1/domain-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/domain-config/set"
+            body: "*"
+        };
     }
     rpc delete (DomainConfigRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/config/v1/domain-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/domain-config/delete"
+            body: "*"
+        };
     }
     rpc get (GetDomainConfigRequest) returns (DomainConfigInfo) {
-        option (google.api.http) = { get: "/config/v1/domain-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/domain-config/get"
+            body: "*"
+        };
     }
     rpc list (DomainConfigQuery) returns (DomainConfigsInfo) {
         option (google.api.http) = {
-            get: "/config/v1/domain-config"
-            additional_bindings {
-                post: "/config/v1/domain-config/search"
-            }
+            post: "/config/v1/domain-config/list"
+            body: "*"
         };
     }
     rpc stat (DomainConfigStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/config/v1/domain-config/stat" };
+        option (google.api.http) = {
+            post: "/config/v1/domain-config/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/config/v1/user_config.proto
+++ b/proto/spaceone/api/config/v1/user_config.proto
@@ -15,30 +15,46 @@ import "spaceone/api/core/v1/query.proto";
 
 service UserConfig {
     rpc create (SetUserConfigRequest) returns (UserConfigInfo) {
-        option (google.api.http) = { post: "/config/v1/user-configs" };
+        option (google.api.http) = {
+            post: "/config/v1/user-config/create"
+            body: "*"
+        };
     }
     rpc update (SetUserConfigRequest) returns (UserConfigInfo) {
-        option (google.api.http) = { put: "/config/v1/user-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/user-config/update"
+            body: "*"
+        };
     }
     rpc set (SetUserConfigRequest) returns (UserConfigInfo) {
-        option (google.api.http) = { post: "/config/v1/user-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/user-config/set"
+            body: "*"
+        };
     }
     rpc delete (UserConfigRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/config/v1/user-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/user-config/delete"
+            body: "*"
+        };
     }
     rpc get (GetUserConfigRequest) returns (UserConfigInfo) {
-        option (google.api.http) = { get: "/config/v1/user-config/{name}" };
+        option (google.api.http) = {
+            post: "/config/v1/user-config/get"
+            body: "*"
+        };
     }
     rpc list (UserConfigQuery) returns (UserConfigsInfo) {
         option (google.api.http) = {
-            get: "/config/v1/user-configs"
-            additional_bindings {
-                post: "/config/v1/user-configs/search"
-            }
+            post: "/config/v1/user-config/list"
+            body: "*"
         };
     }
     rpc stat (UserConfigStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/config/v1/user-configs/stat" };
+        option (google.api.http) = {
+            post: "/config/v1/user-config/stat"
+            body: "*"
+        };
     }
 }
 

--- a/proto/spaceone/api/config/v1/user_config.proto
+++ b/proto/spaceone/api/config/v1/user_config.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package spaceone.api.config.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/config/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- modify `config` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate GO code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 

### Known issue