### PR TITLE
Modify file_manager service http request url at proto file

### DIFF
--- a/proto/spaceone/api/file_manager/v1/file.proto
+++ b/proto/spaceone/api/file_manager/v1/file.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package spaceone.api.file_manager.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/file_manager/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
@@ -10,30 +12,46 @@ import "spaceone/api/core/v1/query.proto";
 
 service File {
     rpc add (CreateFileRequest) returns (FileInfo) {
-        option (google.api.http) = { post: "/file-manager/v1/files" };
+        option (google.api.http) = {
+            post: "/file-manager/v1/file/add"
+            body: "*"
+        };
     }
     rpc update (UpdateFileRequest) returns (FileInfo) {
-        option (google.api.http) = { put: "/file-manager/v1/file/{file_id}" };
+        option (google.api.http) = {
+            post: "/file-manager/v1/file/update"
+            body: "*"
+        };
     }
     rpc delete (FileRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = { delete: "/file-manager/v1/file/{file_id}" };
+        option (google.api.http) = {
+            post: "/file-manager/v1/file/delete"
+            body: "*"
+        };
     }
     rpc get_download_url (FileRequest) returns (FileInfo) {
-        option (google.api.http) = { get: "/file-manager/v1/file/{file_id}/download-url" };
+        option (google.api.http) = {
+            post: "/file-manager/v1/file/get-download-url"
+            body: "*"
+        };
     }
     rpc get (GetFileRequest) returns (FileInfo) {
-        option (google.api.http) = { get: "/file-manager/v1/file/{file_id}" };
+        option (google.api.http) = {
+            post: "/file-manager/v1/file/get"
+            body: "*"
+        };
     }
     rpc list (FileQuery) returns (FilesInfo) {
         option (google.api.http) = {
-            get: "/file-manager/v1/files"
-            additional_bindings {
-                post: "/file-manager/v1/files/search"
-            }
+            post: "/file-manager/v1/file/list"
+            body: "*"
         };
     }
     rpc stat (FileStatQuery) returns (google.protobuf.Struct) {
-        option (google.api.http) = { post: "/file-manager/v1/files/stat" };
+        option (google.api.http) = {
+            post: "/file-manager/v1/file/stat"
+            body: "*"
+        };
     }
 }
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- modify `file-manager` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate GO code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 

### Known issue