### PR TITLE
Modify board service http request url at proto file

### DIFF
--- a/proto/spaceone/api/board/v1/board.proto
+++ b/proto/spaceone/api/board/v1/board.proto
@@ -5,107 +5,81 @@ syntax = "proto3";
 
 package spaceone.api.board.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/board/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "spaceone/api/core/v1/query.proto";
 
 service Board {
-  /*
-  desc: Creates a new Board with SYSTEM permission. The `name` of the board is only required. You can add one or more `categories` representing the Board's attributes.
-  request_example: >-
-    {
-      "name": "notice",
-      "categories": ["admin", "developer", "devops"],
-      "tags": {"a": "b"}
-    }
-  response_example: >-
-    {
-        "board_id": "board-123456789012",
+    /*
+    desc: Creates a new Board with SYSTEM permission. The `name` of the board is only required. You can add one or more `categories` representing the Board's attributes.
+    request_example: >-
+      {
         "name": "notice",
+        "categories": ["admin", "developer", "devops"],
+        "tags": {"a": "b"}
+      }
+    response_example: >-
+      {
+          "board_id": "board-123456789012",
+          "name": "notice",
+          "categories": [
+              "admin",
+              "developer",
+              "devops"
+          ],
+          "tags": {
+              "a": "b"
+          },
+          "created_at": "2022-01-01T06:47:27.759Z"
+      }
+    */
+    rpc create (CreateBoardRequest) returns (BoardInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/create"
+            body: "*"
+        };
+    }
+    /*
+    desc: Updates a specific Board with SYSTEM permission. You can make changes in Board settings, including `name` and `tags`.
+    request_example: >-
+      {
+        "board_id": "board-123456789012",
+        "name": "system notice",
+        "tags": {"b": "c"}
+      }
+    response_example: >-
+      {
+        "board_id": "board-123456789012",
+        "name": "system notice",
         "categories": [
             "admin",
             "developer",
             "devops"
         ],
         "tags": {
-            "a": "b"
+            "b": "c"
         },
         "created_at": "2022-01-01T06:47:27.759Z"
+      }
+    */
+    rpc update (UpdateBoardRequest) returns (BoardInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/update"
+            body: "*"
+        };
     }
-  */
-  rpc create (CreateBoardRequest) returns (BoardInfo) {
-    option (google.api.http) = {post: "/board/v1/boards"};
-  }
-  /*
-  desc: Updates a specific Board with SYSTEM permission. You can make changes in Board settings, including `name` and `tags`.
-  request_example: >-
-    {
-      "board_id": "board-123456789012",
-      "name": "system notice",
-      "tags": {"b": "c"}
-    }
-  response_example: >-
-    {
-      "board_id": "board-123456789012",
-      "name": "system notice",
-      "categories": [
-          "admin",
-          "developer",
-          "devops"
-      ],
-      "tags": {
-          "b": "c"
-      },
-      "created_at": "2022-01-01T06:47:27.759Z"
-    }
-  */
-  rpc update (UpdateBoardRequest) returns (BoardInfo) {
-    option (google.api.http) = {put: "/board/v1/board/{board_id}"};
-  }
-  /*
-  desc: Adds or changes `categories` of a specific Board with SYSTEM permission. A change in `categories` of a Board does not affect the `category` of the child Posts.
-  request_example: >-
-    {
-      "board_id": "board-123456789012",
-      "categories": ["Developer", "SRE", "Devops"]
-    }
-  response_example: >-
-    {
-      "board_id": "board-123456789012",
-      "name": "dev-notice",
-      "categories": [
-          "Developer",
-          "SRE",
-          "Devops"
-      ],
-      "tags": {
-          "b": "c"
-      },
-      "created_at": "2022-01-01T05:24:19.758Z"
-    }
-  */
-  rpc set_categories (SetBoardCategoriesRequest) returns (BoardInfo){
-    option (google.api.http) = {put: "/board/v1/board/{board_id}/set-categories"};
-  }
-  /*
-  desc: Deletes a specific Board with `SYSTEM` permission. You can delete a Board regardless of the presence of Posts created under the Board.
-  request_example: >-
-    {
-      "board_id": "board-123456789012"
-    }
-  */
-  rpc delete (BoardRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {delete: "/board/v1/board/{board_id}"};
-  }
-  /*
-  desc: Gets a specific Board. You must specify the `board_id` of the Board to get. Prints detailed information about the Board, including `name`, `categories`.
-  request_example: >-
-    {
-        "board_id": "board-123456789012"
-    }
-  response_example: >-
-    {
+    /*
+    desc: Adds or changes `categories` of a specific Board with SYSTEM permission. A change in `categories` of a Board does not affect the `category` of the child Posts.
+    request_example: >-
+      {
+        "board_id": "board-123456789012",
+        "categories": ["Developer", "SRE", "Devops"]
+      }
+    response_example: >-
+      {
         "board_id": "board-123456789012",
         "name": "dev-notice",
         "categories": [
@@ -117,118 +91,162 @@ service Board {
             "b": "c"
         },
         "created_at": "2022-01-01T05:24:19.758Z"
-    }
-  */
-  rpc get (GetBoardRequest) returns (BoardInfo) {
-    option (google.api.http) = {get: "/board/v1/board/{board_id}"};
-  }
-  /*
-  desc: Gets a list of all Boards. You can use a query to get a filtered list of Boards.
-  request_example: >-
-    {
-        "query": {}
-    }
-  response_example: >-
-    {
-        "results": [
-            {
-                "board_id": "board-123456789012",
-                "name": "dev-notice",
-                "categories": [
-                    "flower",
-                    "school",
-                    "spaceone"
-                ],
-                "tags": {
-                    "b": "c"
-                },
-                "created_at": "2022-01-01T05:16:08.549Z"
-            },
-            {
-                "board_id": "board-987654321098",
-                "name": "notice",
-                "tags": {
-                    "a": "b"
-                },
-                "created_at": "2022-01-01T05:24:19.758Z"
-            }
-        ],
-        "total_count": 2
-    }
-   */
-  rpc list (BoardQuery) returns (BoardsInfo) {
-    option (google.api.http) = {
-      get: "/board/v1/boards"
-      additional_bindings {
-        post: "/board/v1/boards/search"
       }
-    };
-  }
-  rpc stat (BoardStatQuery) returns (google.protobuf.Struct) {
-    option (google.api.http) = {post: "/board/v1/boards/stat"};
-  }
+    */
+    rpc set_categories (SetBoardCategoriesRequest) returns (BoardInfo){
+        option (google.api.http) = {
+            post: "/board/v1/board/set-categories"
+            body: "*"
+        };
+    }
+    /*
+    desc: Deletes a specific Board with `SYSTEM` permission. You can delete a Board regardless of the presence of Posts created under the Board.
+    request_example: >-
+      {
+        "board_id": "board-123456789012"
+      }
+    */
+    rpc delete (BoardRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+            post: "/board/v1/board/delete"
+            body: "*"
+        };
+    }
+    /*
+    desc: Gets a specific Board. You must specify the `board_id` of the Board to get. Prints detailed information about the Board, including `name`, `categories`.
+    request_example: >-
+      {
+          "board_id": "board-123456789012"
+      }
+    response_example: >-
+      {
+          "board_id": "board-123456789012",
+          "name": "dev-notice",
+          "categories": [
+              "Developer",
+              "SRE",
+              "Devops"
+          ],
+          "tags": {
+              "b": "c"
+          },
+          "created_at": "2022-01-01T05:24:19.758Z"
+      }
+    */
+    rpc get (GetBoardRequest) returns (BoardInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/get"
+            body: "*"
+        };
+    }
+    /*
+    desc: Gets a list of all Boards. You can use a query to get a filtered list of Boards.
+    request_example: >-
+      {
+          "query": {}
+      }
+    response_example: >-
+      {
+          "results": [
+              {
+                  "board_id": "board-123456789012",
+                  "name": "dev-notice",
+                  "categories": [
+                      "flower",
+                      "school",
+                      "spaceone"
+                  ],
+                  "tags": {
+                      "b": "c"
+                  },
+                  "created_at": "2022-01-01T05:16:08.549Z"
+              },
+              {
+                  "board_id": "board-987654321098",
+                  "name": "notice",
+                  "tags": {
+                      "a": "b"
+                  },
+                  "created_at": "2022-01-01T05:24:19.758Z"
+              }
+          ],
+          "total_count": 2
+      }
+     */
+    rpc list (BoardQuery) returns (BoardsInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/list"
+            body: "*"
+        };
+    }
+    rpc stat (BoardStatQuery) returns (google.protobuf.Struct) {
+        option (google.api.http) = {
+            post: "/board/v1/board/stat"
+            body: "*"
+        };
+    }
 }
 
 message CreateBoardRequest {
-  // is_required: true
-  string name = 1;
-  // is_required: false
-  repeated string categories = 2;
-  // is_required: false
-  google.protobuf.Struct tags = 3;
+    // is_required: true
+    string name = 1;
+    // is_required: false
+    repeated string categories = 2;
+    // is_required: false
+    google.protobuf.Struct tags = 3;
 }
 
 message UpdateBoardRequest {
-  // is_required: true
-  string board_id = 1;
-  // is_required: false
-  string name = 2;
-  // is_required: false
-  google.protobuf.Struct tags = 3;
+    // is_required: true
+    string board_id = 1;
+    // is_required: false
+    string name = 2;
+    // is_required: false
+    google.protobuf.Struct tags = 3;
 }
 
 message SetBoardCategoriesRequest{
-  // is_required: true
-  string board_id = 1;
-  // is_required: false
-  repeated string categories = 2;
+    // is_required: true
+    string board_id = 1;
+    // is_required: false
+    repeated string categories = 2;
 }
 
 message BoardRequest {
-  // is_required: true
-  string board_id = 1;
+    // is_required: true
+    string board_id = 1;
 }
 
 message GetBoardRequest {
-  // is_required: true
-  string board_id = 1;
-  // is_required: false
-  repeated string only = 3;
+    // is_required: true
+    string board_id = 1;
+    // is_required: false
+    repeated string only = 3;
 }
 
 message BoardQuery {
-  // is_required: false
-  string board_id = 1;
-  // is_required: false
-  string name = 2;
-  // is_required: false
-  spaceone.api.core.v1.Query query = 3;
+    // is_required: false
+    string board_id = 1;
+    // is_required: false
+    string name = 2;
+    // is_required: false
+    spaceone.api.core.v1.Query query = 3;
 }
 
 message BoardStatQuery {
-  // is_required: true
-  spaceone.api.core.v1.StatisticsQuery query = 1;
+    // is_required: true
+    spaceone.api.core.v1.StatisticsQuery query = 1;
 }
 
 message BoardInfo {
-  string board_id = 1;
-  string name = 2;
-  repeated string categories = 3;
-  google.protobuf.Struct tags = 4;
-  string created_at = 11;
+    string board_id = 1;
+    string name = 2;
+    repeated string categories = 3;
+    google.protobuf.Struct tags = 4;
+    string created_at = 11;
 }
 
 message BoardsInfo {
-  repeated BoardInfo results = 1;
-  int32 total_count = 2;
+    repeated BoardInfo results = 1;
+    int32 total_count = 2;
 }

--- a/proto/spaceone/api/board/v1/post.proto
+++ b/proto/spaceone/api/board/v1/post.proto
@@ -5,345 +5,363 @@ syntax = "proto3";
 
 package spaceone.api.board.v1;
 
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/board/v1";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "spaceone/api/core/v1/query.proto";
 
 service Post {
-  /*
-  desc: Creates a new Post under a specific Board. You must specify the `board_id`, `title`, and `contents`. The parameter `category` is not required but can be set in the scope of `categories` specified in the parent Board. You can make the new Post pinned or pop up by adjusting the parameters.
-  request_example: >-
-    {
-        "board_id": "board-123456789012",
-        "category": "developer",
-        "title": "title",
-        "contents": "This is contents.",
-        "options": {"is_popup": true},
-        "writer": "user1",
-        "domain_id": "domain-123456789012"
-    }
-  response_example: >-
-    {
-        "board_id": "board-123456789012",
-        "post_id": "post-123456789012",
-        "post_type": "INTERNAL",
-        "category": "developer",
-        "title": "title",
-        "contents": "This is contents.",
-        "options": {
-            "is_pinned": false,
-            "is_popup": true
-        },
-        "view_count": 0,
-        "writer": "user1",
-        "scope": "DOMAIN",
-        "domain_id": "domain-123456789012",
-        "user_id": "user1@email.com",
-        "created_at": "2022-01-01T01:06:23.732Z",
-        "updated_at": "2022-01-01T01:06:23.732Z"
-    }
-   */
-  rpc create (CreatePostRequest) returns (PostInfo) {
-    option (google.api.http) = {post: "/board/v1/board/{board_id}/posts"};
-  }
-  /*
-  desc: Updates a specific Post. You can make changes in Post settings, except `board_id`, `post_id`, and `domain_id`.
-  request_example: >-
-    {
-        "board_id": "board-123456789012",
-        "post_id": "post-2118473ce15e",
-        "category": "developer",
-        "title": "title2",
-        "contents": "this is contents2.",
-        "options": {
-            "is_popup": false,
-            "is_pinned": true
-        },
-        "writer": "user1",
-        "domain_id": "domain-123456789012"
-    }
-  response_example: >-
-    {
-        "board_id": "board-123456789012",
-        "post_id": "post-123456789012",
-        "post_type": "INTERNAL",
-        "category": "developer",
-        "title": "title2",
-        "contents": "this is contents2.",
-        "options": {
-            "is_popup": false,
-            "is_pinned": true
-        },
-        "view_count": 1,
-        "writer": "user1",
-        "scope": "DOMAIN",
-        "domain_id": "domain-123456789012",
-        "user_id": "user1@email.com",
-        "created_at": "2022-06-13T01:06:23.732Z",
-        "updated_at": "2022-06-13T01:06:23.732Z"
-    }
-   */
-  rpc update (UpdatePostRequest) returns (PostInfo) {
-    option (google.api.http) = {put: "/board/v1/board/{board_id}/post/{post_id}"};
-  }
-  /*
-  desc: Not Implemented
-   */
-  rpc send_notification (SendNotificationRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {post: "/board/v1/board/{board_id}/post/{post_id}/send-notification"};
-  }
-  /*
-  desc: Deletes a specific Post. You must specify the `post_id` of the Post to delete, and the `board_id` of the Board where the child Post to delete belongs.
-  request_example: >-
-    {
-      "board_id": "board-b9aa34e65c60",
-      "post_id": "post-2118473ce15e",
-      "domain_id": "domain-123456789012"
-    }
-   */
-  rpc delete (PostRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {delete: "/board/v1/board/{board_id}/post/{post_id}"};
-  }
-  /*
-  desc: Gets a specific Post. You must specify the `post_id` of the Post to get, and the `board_id` of the Board where the child Post to get belongs. Prints detailed information about the Post.
-  request_example: >-
-    {
-        "board_id": "board-b9aa34e65c60",
-        "post_id": "post-2118473ce15e",
-        "domain_id": "domain-58010aa2e451"
-    }
-  response_example: >-
-    {
-        "board_id": "board-b9aa34e65c60",
-        "post_id": "post-2118473ce15e",
-        "post_type": "INTERNAL",
-        "category": "flower",
-        "title": "title",
-        "contents": "this is contents.",
-        "options": {
-            "is_pinned": false,
-            "is_popup": true
-        },
-        "view_count": 2,
-        "writer": "seolmin",
-        "scope": "DOMAIN",
-        "domain_id": "domain-58010aa2e451",
-        "user_id": "supervisor",
-        "created_at": "2022-06-13T01:06:23.732Z",
-        "updated_at": "2022-06-13T01:06:23.732Z"
-    }
-   */
-  rpc get (GetPostRequest) returns (PostInfo) {
-    option (google.api.http) = {get: "/board/v1/board/{board_id}/post/{post_id}"};
-  }
-  /*
-  desc: Gets a list of all Posts. You can use a query to get a filtered list of Posts.
-  request_example: >-
-    {
-        "board_id": "board-b9aa34e65c60",
-        "query": {}
-    }
-  response_example: >-
-    {
-        "results": [
-            {
-                "board_id": "board-b9aa34e65c60",
-                "post_id": "post-2118473ce15e",
-                "post_type": "INTERNAL",
-                "category": "spaceone",
-                "title": "title2",
-                "contents": "this is contents2.",
-                "options": {
-                    "is_popup": false,
-                    "is_pinned": true
-                },
-                "view_count": 3,
-                "writer": "seolmin2",
-                "scope": "DOMAIN",
-                "domain_id": "domain-58010aa2e451",
-                "user_id": "user1@email.com",
-                "created_at": "2022-06-13T01:06:23.732Z",
-                "updated_at": "2022-06-13T01:06:23.732Z"
-            },
-            {
-                "board_id": "board-b9aa34e65c60",
-                "post_id": "post-532ae1191233",
-                "post_type": "INTERNAL",
-                "category": "flower",
-                "title": "작업공지",
-                "contents": "This is description",
-                "options": {
-                    "is_pinned": true,
-                    "is_popup": true
-                },
-                "writer": "권설민",
-                "scope": "PUBLIC",
-                "user_id": "supervisor",
-                "created_at": "2022-06-10T07:01:44.384Z",
-                "updated_at": "2022-06-10T07:01:44.384Z"
-            }
-        ],
-        "total_count": 2
-    }
-   */
-  rpc list (PostQuery) returns (PostsInfo) {
-    option (google.api.http) = {
-      get: "/board/v1/board/{board_id}/posts"
-      additional_bindings {
-        post: "/board/v1/board/{board_id}/posts/search"
+    /*
+    desc: Creates a new Post under a specific Board. You must specify the `board_id`, `title`, and `contents`. The parameter `category` is not required but can be set in the scope of `categories` specified in the parent Board. You can make the new Post pinned or pop up by adjusting the parameters.
+    request_example: >-
+      {
+          "board_id": "board-123456789012",
+          "category": "developer",
+          "title": "title",
+          "contents": "This is contents.",
+          "options": {"is_popup": true},
+          "writer": "user1",
+          "domain_id": "domain-123456789012"
       }
-    };
-  }
-  rpc stat (PostStatQuery) returns (google.protobuf.Struct) {
-    option (google.api.http) = {post: "/board/v1/board/{board_id}/posts/stat"};
-  }
+    response_example: >-
+      {
+          "board_id": "board-123456789012",
+          "post_id": "post-123456789012",
+          "post_type": "INTERNAL",
+          "category": "developer",
+          "title": "title",
+          "contents": "This is contents.",
+          "options": {
+              "is_pinned": false,
+              "is_popup": true
+          },
+          "view_count": 0,
+          "writer": "user1",
+          "scope": "DOMAIN",
+          "domain_id": "domain-123456789012",
+          "user_id": "user1@email.com",
+          "created_at": "2022-01-01T01:06:23.732Z",
+          "updated_at": "2022-01-01T01:06:23.732Z"
+      }
+     */
+    rpc create (CreatePostRequest) returns (PostInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/create"
+            body: "*"
+        };
+    }
+    /*
+    desc: Updates a specific Post. You can make changes in Post settings, except `board_id`, `post_id`, and `domain_id`.
+    request_example: >-
+      {
+          "board_id": "board-123456789012",
+          "post_id": "post-2118473ce15e",
+          "category": "developer",
+          "title": "title2",
+          "contents": "this is contents2.",
+          "options": {
+              "is_popup": false,
+              "is_pinned": true
+          },
+          "writer": "user1",
+          "domain_id": "domain-123456789012"
+      }
+    response_example: >-
+      {
+          "board_id": "board-123456789012",
+          "post_id": "post-123456789012",
+          "post_type": "INTERNAL",
+          "category": "developer",
+          "title": "title2",
+          "contents": "this is contents2.",
+          "options": {
+              "is_popup": false,
+              "is_pinned": true
+          },
+          "view_count": 1,
+          "writer": "user1",
+          "scope": "DOMAIN",
+          "domain_id": "domain-123456789012",
+          "user_id": "user1@email.com",
+          "created_at": "2022-06-13T01:06:23.732Z",
+          "updated_at": "2022-06-13T01:06:23.732Z"
+      }
+     */
+    rpc update (UpdatePostRequest) returns (PostInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/update"
+            body: "*"
+        };
+    }
+    /*
+    desc: Not Implemented
+     */
+    rpc send_notification (SendNotificationRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+            post: "/board/v1/board/send-notification"
+            body: "*"
+        };
+    }
+    /*
+    desc: Deletes a specific Post. You must specify the `post_id` of the Post to delete, and the `board_id` of the Board where the child Post to delete belongs.
+    request_example: >-
+      {
+        "board_id": "board-b9aa34e65c60",
+        "post_id": "post-2118473ce15e",
+        "domain_id": "domain-123456789012"
+      }
+     */
+    rpc delete (PostRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+            post: "/board/v1/board/delete"
+            body: "*"
+        };
+    }
+    /*
+    desc: Gets a specific Post. You must specify the `post_id` of the Post to get, and the `board_id` of the Board where the child Post to get belongs. Prints detailed information about the Post.
+    request_example: >-
+      {
+          "board_id": "board-b9aa34e65c60",
+          "post_id": "post-2118473ce15e",
+          "domain_id": "domain-58010aa2e451"
+      }
+    response_example: >-
+      {
+          "board_id": "board-b9aa34e65c60",
+          "post_id": "post-2118473ce15e",
+          "post_type": "INTERNAL",
+          "category": "flower",
+          "title": "title",
+          "contents": "this is contents.",
+          "options": {
+              "is_pinned": false,
+              "is_popup": true
+          },
+          "view_count": 2,
+          "writer": "seolmin",
+          "scope": "DOMAIN",
+          "domain_id": "domain-58010aa2e451",
+          "user_id": "supervisor",
+          "created_at": "2022-06-13T01:06:23.732Z",
+          "updated_at": "2022-06-13T01:06:23.732Z"
+      }
+     */
+    rpc get (GetPostRequest) returns (PostInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/get"
+            body: "*"
+        };
+    }
+    /*
+    desc: Gets a list of all Posts. You can use a query to get a filtered list of Posts.
+    request_example: >-
+      {
+          "board_id": "board-b9aa34e65c60",
+          "query": {}
+      }
+    response_example: >-
+      {
+          "results": [
+              {
+                  "board_id": "board-b9aa34e65c60",
+                  "post_id": "post-2118473ce15e",
+                  "post_type": "INTERNAL",
+                  "category": "spaceone",
+                  "title": "title2",
+                  "contents": "this is contents2.",
+                  "options": {
+                      "is_popup": false,
+                      "is_pinned": true
+                  },
+                  "view_count": 3,
+                  "writer": "seolmin2",
+                  "scope": "DOMAIN",
+                  "domain_id": "domain-58010aa2e451",
+                  "user_id": "user1@email.com",
+                  "created_at": "2022-06-13T01:06:23.732Z",
+                  "updated_at": "2022-06-13T01:06:23.732Z"
+              },
+              {
+                  "board_id": "board-b9aa34e65c60",
+                  "post_id": "post-532ae1191233",
+                  "post_type": "INTERNAL",
+                  "category": "flower",
+                  "title": "작업공지",
+                  "contents": "This is description",
+                  "options": {
+                      "is_pinned": true,
+                      "is_popup": true
+                  },
+                  "writer": "권설민",
+                  "scope": "PUBLIC",
+                  "user_id": "supervisor",
+                  "created_at": "2022-06-10T07:01:44.384Z",
+                  "updated_at": "2022-06-10T07:01:44.384Z"
+              }
+          ],
+          "total_count": 2
+      }
+     */
+    rpc list (PostQuery) returns (PostsInfo) {
+        option (google.api.http) = {
+            post: "/board/v1/board/list"
+            body: "*"
+        };
+    }
+    rpc stat (PostStatQuery) returns (google.protobuf.Struct) {
+        option (google.api.http) = {
+            post: "/board/v1/board/stat"
+            body: "*"
+        };
+    }
 }
 
 
 message CreatePostRequest {
-  // is_required: true
-  string board_id = 1;
-  // is_required: false
-  string category = 2;
-  // is_required: true
-  string title = 3;
-  // is_required: true
-  string contents = 4;
-  // is_required: false
-  google.protobuf.Struct options = 5;
-  // is_required: false
-  string writer = 6;
-  // is_required: false
-  repeated string files = 7;
-  // is_required: false
-  string domain_id = 10;
+    // is_required: true
+    string board_id = 1;
+    // is_required: false
+    string category = 2;
+    // is_required: true
+    string title = 3;
+    // is_required: true
+    string contents = 4;
+    // is_required: false
+    google.protobuf.Struct options = 5;
+    // is_required: false
+    string writer = 6;
+    // is_required: false
+    repeated string files = 7;
+    // is_required: false
+    string domain_id = 10;
 }
 
 message UpdatePostRequest {
-  // is_required: true
-  string board_id = 1;
-  // is_required: true
-  string post_id = 2;
-  // is_required: false
-  string category = 3;
-  // is_required: false
-  string title = 4;
-  // is_required: false
-  string contents = 5;
-  // is_required: false
-  google.protobuf.Struct options = 6;
-  // is_required: false
-  string writer = 7;
-  // is_required: false
-  repeated string files = 8;
-  // is_required: false
-  string domain_id = 10;
+    // is_required: true
+    string board_id = 1;
+    // is_required: true
+    string post_id = 2;
+    // is_required: false
+    string category = 3;
+    // is_required: false
+    string title = 4;
+    // is_required: false
+    string contents = 5;
+    // is_required: false
+    google.protobuf.Struct options = 6;
+    // is_required: false
+    string writer = 7;
+    // is_required: false
+    repeated string files = 8;
+    // is_required: false
+    string domain_id = 10;
 }
 
 message SendNotificationRequest {
-  // is_required: true
-  string board_id = 1;
-  // is_required: true
-  string post_id = 2;
-  // is_required: false
-  string domain_id = 3;
+    // is_required: true
+    string board_id = 1;
+    // is_required: true
+    string post_id = 2;
+    // is_required: false
+    string domain_id = 3;
 }
 
 message PostRequest {
-  // is_required: true
-  string board_id = 1;
-  // is_required: true
-  string post_id = 2;
-  // is_required: false
-  string domain_id = 3;
+    // is_required: true
+    string board_id = 1;
+    // is_required: true
+    string post_id = 2;
+    // is_required: false
+    string domain_id = 3;
 }
 
 message GetPostRequest {
-  // is_required: true
-  string board_id = 1;
-  // is_required: true
-  string post_id = 2;
-  // is_required: false
-  repeated string only = 3;
-  // is_required: false
-  string domain_id = 7;
+    // is_required: true
+    string board_id = 1;
+    // is_required: true
+    string post_id = 2;
+    // is_required: false
+    repeated string only = 3;
+    // is_required: false
+    string domain_id = 7;
 }
 
 message PostQuery {
-  enum Scope {
-    SCOPE_NONE = 0;
-    PUBLIC = 1;
-    DOMAIN = 2;
-  }
+    enum Scope {
+        SCOPE_NONE = 0;
+        PUBLIC = 1;
+        DOMAIN = 2;
+    }
 
-  enum PostType {
-    POST_TYPE_NONE = 0;
-    SYSTEM = 1;
-    INTERNAL = 2;
-  }
+    enum PostType {
+        POST_TYPE_NONE = 0;
+        SYSTEM = 1;
+        INTERNAL = 2;
+    }
 
-  // is_required: true
-  string board_id = 1;
-  // is_required: false
-  string post_id = 2;
-  // is_required: false
-  PostType post_type = 3;
-  // is_required: false
-  string category = 4;
-  // is_required: false
-  string writer = 5;
-  // is_required: false
-  Scope scope = 6;
-  // is_required: false
-  string user_id = 7;
-  // is_required: false
-  string user_domain_id = 8;
-  // is_required: false
-  string domain_id = 9;
-  // is_required: false
-  spaceone.api.core.v1.Query query = 10;
+    // is_required: true
+    string board_id = 1;
+    // is_required: false
+    string post_id = 2;
+    // is_required: false
+    PostType post_type = 3;
+    // is_required: false
+    string category = 4;
+    // is_required: false
+    string writer = 5;
+    // is_required: false
+    Scope scope = 6;
+    // is_required: false
+    string user_id = 7;
+    // is_required: false
+    string user_domain_id = 8;
+    // is_required: false
+    string domain_id = 9;
+    // is_required: false
+    spaceone.api.core.v1.Query query = 10;
 }
 
 message PostStatQuery {
-  // is_required: true
-  spaceone.api.core.v1.StatisticsQuery query = 1;
-  // is_required: true
-  string domain_id = 2;
+    // is_required: true
+    spaceone.api.core.v1.StatisticsQuery query = 1;
+    // is_required: true
+    string domain_id = 2;
 }
 
 message PostInfo {
-  enum Scope {
-    SCOPE_NONE = 0;
-    PUBLIC = 1;
-    DOMAIN = 2;
-  }
+    enum Scope {
+        SCOPE_NONE = 0;
+        PUBLIC = 1;
+        DOMAIN = 2;
+    }
 
-  enum PostType {
-    POST_TYPE_NONE = 0;
-    SYSTEM = 1;
-    INTERNAL = 2;
-  }
+    enum PostType {
+        POST_TYPE_NONE = 0;
+        SYSTEM = 1;
+        INTERNAL = 2;
+    }
 
-  string board_id = 1;
-  string post_id = 2;
-  PostType post_type = 3;
-  string category = 4;
-  string title = 5;
-  string contents = 6;
-  google.protobuf.Struct options = 7;
-  int32 view_count = 8;
-  string writer = 9;
-  Scope scope = 10;
-  google.protobuf.ListValue files = 11;
-  string domain_id = 21;
-  string user_id = 22;
-  string user_domain_id = 23;
-  string created_at = 31;
-  string updated_at = 32;
+    string board_id = 1;
+    string post_id = 2;
+    PostType post_type = 3;
+    string category = 4;
+    string title = 5;
+    string contents = 6;
+    google.protobuf.Struct options = 7;
+    int32 view_count = 8;
+    string writer = 9;
+    Scope scope = 10;
+    google.protobuf.ListValue files = 11;
+    string domain_id = 21;
+    string user_id = 22;
+    string user_domain_id = 23;
+    string created_at = 31;
+    string updated_at = 32;
 }
 
 message PostsInfo {
-  repeated PostInfo results = 1;
-  int32 total_count = 2;
+    repeated PostInfo results = 1;
+    int32 total_count = 2;
 }


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description
- modify `board` service http request url at proto file
   - format is `{service}/{version}/{resource}/{verb}`
   - all http method is `post`
   - declare request body for all request
 - add `option go_package`
    - It's about where Go package's import
       In order to generate Go code this is must be declared in `.proto` file. Here is official [documentation](https://protobuf.dev/reference/go/go-generated/#package) for this 
### Known issue