### PR TITLE
improve: add remote_repository field for provider_info

### DIFF
--- a/proto/spaceone/api/repository/v2/provider.proto
+++ b/proto/spaceone/api/repository/v2/provider.proto
@@ -141,6 +141,7 @@ message ProviderInfo {
     repeated Reference reference = 10;
     google.protobuf.ListValue labels = 11;
     google.protobuf.Struct tags = 12;
+    google.protobuf.Struct remote_repository = 13;
     string domain_id = 21;
     string created_at = 31;
 }


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
As a result of discussing the provider resource, we decided to add a 'remote_repository' field to the provider_info.
This PR relates to that decision.

(I didn't create a branch for this because this issue only involves fixing a protobuf message field of the provider resource.)

### Known issue