### PR TITLE
Add workspace group details API

### DIFF
--- a/proto/spaceone/api/identity/v2/workspace_group_details.proto
+++ b/proto/spaceone/api/identity/v2/workspace_group_details.proto
@@ -1,0 +1,156 @@
+syntax = "proto3";
+
+package spaceone.api.identity.v2;
+
+option go_package = "github.com/cloudforet-io/api/dist/go/spaceone/api/identity/v2";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+import "google/api/annotations.proto";
+import "spaceone/api/core/v2/query.proto";
+
+service WorkspaceGroupDetails {
+  rpc update (UpdateWorkspaceGroupDetailsRequest) returns (WorkspaceGroupDetailsInfo) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/update"
+      body: "*"
+    };
+  }
+
+  rpc delete (DeleteWorkspaceGroupDetailsRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/delete"
+      body: "*"
+    };
+  }
+
+  rpc add_workspaces (WorkspacesWorkspaceGroupDetailsRequest) returns (WorkspaceGroupDetailsInfo) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/add-workspaces"
+      body: "*"
+    };
+  }
+
+  rpc remove_workspaces (WorkspacesWorkspaceGroupDetailsRequest) returns (WorkspaceGroupDetailsInfo) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/remove-workspaces"
+      body: "*"
+    };
+  }
+
+  rpc find_users (WorkspaceGroupDetailsFindRequest) returns (WorkspaceGroupDetailsUsersSummaryInfo) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/find-users"
+      body: "*"
+    };
+  }
+
+  rpc add_users (AddUsersWorkspaceGroupDetailsRequest) returns (WorkspaceGroupDetailsInfo) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/add-users"
+      body: "*"
+    };
+  }
+
+  rpc remove_users (RemoveUsersWorkspaceGroupDetailsRequest) returns (WorkspaceGroupDetailsInfo) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/remove-users"
+      body: "*"
+    };
+  }
+
+  rpc get_workspace_groups (WorkspaceGroupDetailsRequest) returns (WorkspaceGroupsDetailsInfo) {
+    option (google.api.http) = {
+      post: "/identity/v2/workspace-group-details/get-workspace-group-details"
+      body: "*"
+    };
+  }
+}
+
+message UpdateWorkspaceGroupDetailsRequest {
+  string workspace_group_id = 1;
+  // +optional
+  string name = 2;
+  // +optional
+  google.protobuf.Struct tags = 3;
+}
+
+message WorkspacesWorkspaceGroupDetailsRequest {
+  string workspace_group_id = 1;
+  repeated string workspaces = 2;
+}
+
+message WorkspaceGroupDetailsFindRequest {
+  enum State {
+    NONE = 0;
+    ENABLED = 1;
+    DISABLED = 2;
+    PENDING = 3;
+  }
+
+  string keyword = 1;
+  // +optional
+  State state = 2;
+  // +optional
+  spaceone.api.core.v2.Page page = 3;
+  string workspace_group_id = 21;
+}
+
+message WorkspaceGroupDetailsUser {
+  string user_id = 1;
+  string role_id = 2;
+  string role_type = 3;
+}
+
+message AddUsersWorkspaceGroupDetailsRequest {
+  string workspace_group_id = 1;
+  repeated WorkspaceGroupDetailsUser users = 2;
+}
+
+message RemoveUsersWorkspaceGroupDetailsRequest {
+  string workspace_group_id = 1;
+  repeated string users = 2;
+}
+
+message DeleteWorkspaceGroupDetailsRequest {
+  string workspace_group_id = 1;
+}
+
+message WorkspaceGroupDetailsRequest {
+}
+
+message WorkspaceGroupDetailsInfo {
+  string workspace_group_id = 1;
+  string name = 2;
+  repeated string workspaces = 3;
+  repeated string users = 4;
+  google.protobuf.Struct tags = 5;
+  string created_by = 6;
+  string updated_by = 7;
+  string domain_id = 21;
+  string created_at = 31;
+  string updated_at = 32;
+}
+
+message WorkspaceGroupDetailsUserSummaryInfo {
+  enum State {
+    STATE_NONE = 0;
+    ENABLED = 1;
+    DISABLED = 2;
+    PENDING = 3;
+  }
+
+  string user_id = 1;
+  string name = 2;
+  State state = 3;
+}
+
+message WorkspaceGroupDetailsUsersSummaryInfo {
+  repeated WorkspaceGroupDetailsUserSummaryInfo results = 1;
+  int32 total_count = 2;
+}
+
+message WorkspaceGroupsDetailsInfo {
+  repeated WorkspaceGroupDetailsInfo results = 1;
+  int32 total_count = 2;
+}


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
I created a Workspace Group Details API that can be accessed with the USER Role Type because a Workspace Group only has DOMAIN_ADMIN, WORKSPACE_OWNER, and WORKSPACE_MEMBER Role Types.