### PR TITLE
fix: add update_fields RPC to TaskType, TaskCategory service

### DIFF
--- a/proto/spaceone/api/opsflow/v1/task_category.proto
+++ b/proto/spaceone/api/opsflow/v1/task_category.proto
@@ -23,6 +23,12 @@ service TaskCategory {
             body: "*"
         };
     }
+    rpc update_fields (TaskCategoryUpdateFieldsRequest) returns (TaskCategoryInfo) {
+        option (google.api.http) = {
+            post: "/opsflow/v1/task-category/update_fields"
+            body: "*"
+        };
+    }
     rpc delete (TaskCategoryRequest) returns (google.protobuf.Empty) {
         option (google.api.http) = {
             post: "/opsflow/v1/task-category/delete"
@@ -102,13 +108,17 @@ message TaskCategoryUpdateRequest {
     // +optional
     StatusOptions status_options = 4;
     // +optional
-    repeated TaskField fields = 5;
-    // +optional
-    bool force = 6;
+    bool force = 5;
     // +optional
     google.protobuf.Struct tags = 11;
     // +optional
     string package_id = 21;
+}
+
+message TaskCategoryUpdateFieldsRequest {
+    string category_id = 1;
+    repeated TaskField fields = 2;
+    bool force = 3;
 }
 
 message TaskCategoryRequest {

--- a/proto/spaceone/api/opsflow/v1/task_type.proto
+++ b/proto/spaceone/api/opsflow/v1/task_type.proto
@@ -24,6 +24,12 @@ service TaskType {
             body: "*"
         };
     }
+    rpc update_fields (TaskTypeUpdateFieldsRequest) returns (TaskTypeInfo) {
+        option (google.api.http) = {
+            post: "/opsflow/v1/task-type/update_fields"
+            body: "*"
+        };
+    }
     rpc delete (TaskTypeRequest) returns (google.protobuf.Empty) {
         option (google.api.http) = {
             post: "/opsflow/v1/task-type/delete"
@@ -70,13 +76,17 @@ message TaskTypeUpdateRequest {
     // +optional
     string description = 3;
     // +optional
-    repeated TaskField fields = 4;
-    // +optional
-    repeated string assignee_pool = 5;
+    repeated string assignee_pool = 4;
     // +optional
     google.protobuf.Struct tags = 11;
     // +optional
     string category_id = 21;
+}
+
+message TaskTypeUpdateFieldsRequest {
+    string task_type_id = 1;
+    repeated TaskField fields = 2;
+    bool force = 3;
 }
 
 message TaskTypeRequest {


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- add update_fields RPC to TaskType, TaskCategory service