### PR TITLE
fix: change send_report field type to string in CostReportConfigRequest

### DIFF
--- a/proto/spaceone/api/cost_analysis/v1/cost_report_config.proto
+++ b/proto/spaceone/api/cost_analysis/v1/cost_report_config.proto
@@ -149,7 +149,7 @@ message UpdateCostReportConfigRecipientsRequest {
 message CostReportConfigRequest {
   // The ID of cost report in the Protocol.
   string cost_report_config_id = 1;
-  bool send_report = 2;
+  string send_report = 2;
 }
 
 message CostReportConfigQuery {


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
* change send_report field type to string in CostReportConfigRequest